### PR TITLE
First working merge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,5 @@ before_script:
   - rustup component add rustfmt-preview
 
 script:
-  - cargo fmt --all -- --check
   - cargo build
   - cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ authors = ["Lina Cambridge <lina@mozilla.com>"]
 failure = "0.1.1"
 failure_derive = "0.1.1"
 log = "0.4"
+
+[dev-dependencies]
+env_logger = "0.5.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,4 @@ authors = ["Lina Cambridge <lina@mozilla.com>"]
 [dependencies]
 failure = "0.1.1"
 failure_derive = "0.1.1"
-lazy_static = "1.0"
 log = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,6 @@ extern crate failure;
 extern crate failure_derive;
 
 #[macro_use]
-extern crate lazy_static;
-
-#[macro_use]
 extern crate log;
 
 mod error;

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -124,7 +124,7 @@ impl<'t> Merger<'t> {
     }
 
     pub fn subsumes(&self, tree: &Tree) -> bool {
-        tree.guids().iter().all(|guid| self.mentions(guid))
+        tree.guids().all(|guid| self.mentions(guid))
     }
 
     #[inline]

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -338,7 +338,7 @@ impl<'t> Merger<'t> {
                 let merged_child_node = self.merge_node(&local_child_node.guid,
                                                         Some(local_child_node),
                                                         Some(remote_child_node))?;
-                merged_node.merged_children.push(merged_child_node.into());
+                merged_node.merged_children.push(merged_child_node);
                 return Ok(false);
             }
 
@@ -379,7 +379,7 @@ impl<'t> Merger<'t> {
                     let merged_child_node = self.merge_node(&remote_child_node.guid,
                                                             Some(local_child_node),
                                                             Some(remote_child_node))?;
-                    merged_node.merged_children.push(merged_child_node.into());
+                    merged_node.merged_children.push(merged_child_node);
                     return Ok(false);
                 },
 
@@ -397,7 +397,7 @@ impl<'t> Merger<'t> {
                     let merged_child_node = self.merge_node(&remote_child_node.guid,
                                                             Some(local_child_node),
                                                             Some(remote_child_node))?;
-                    merged_node.merged_children.push(merged_child_node.into());
+                    merged_node.merged_children.push(merged_child_node);
                     return Ok(false);
                 },
             }
@@ -415,7 +415,7 @@ impl<'t> Merger<'t> {
             let merged_child_node = self.merge_node(&remote_child_node.guid,
                                                     local_child_node_by_content,
                                                     Some(remote_child_node))?;
-            merged_node.merged_children.push(merged_child_node.into());
+            merged_node.merged_children.push(merged_child_node);
             return Ok(false);
         }
     }
@@ -483,7 +483,7 @@ impl<'t> Merger<'t> {
                 let merged_child_node = self.merge_node(&local_child_node.guid,
                                                         Some(local_child_node),
                                                         Some(remote_child_node))?;
-                merged_node.merged_children.push(merged_child_node.into());
+                merged_node.merged_children.push(merged_child_node);
                 return Ok(true);
             }
 
@@ -520,7 +520,7 @@ impl<'t> Merger<'t> {
                     let merged_child_node = self.merge_node(&local_child_node.guid,
                                                             Some(local_child_node),
                                                             Some(remote_child_node))?;
-                    merged_node.merged_children.push(merged_child_node.into());
+                    merged_node.merged_children.push(merged_child_node);
                     return Ok(true);
                 },
                 (true, false) => {
@@ -531,7 +531,7 @@ impl<'t> Merger<'t> {
                     let merged_child_node = self.merge_node(&local_child_node.guid,
                                                             Some(local_child_node),
                                                             Some(remote_child_node))?;
-                    merged_node.merged_children.push(merged_child_node.into());
+                    merged_node.merged_children.push(merged_child_node);
                     return Ok(true);
                 },
                 (false, _) => {
@@ -558,14 +558,14 @@ impl<'t> Merger<'t> {
                 let merged_child_node = self.merge_node(&remote_child_node_by_content.guid,
                                                         Some(local_child_node),
                                                         Some(remote_child_node_by_content))?;
-                merged_node.merged_children.push(merged_child_node.into());
+                merged_node.merged_children.push(merged_child_node);
                 return Ok(false);
             } else {
                 // The local child doesn't exist remotely, but we still need to walk
                 // its children.
                 let merged_child_node =
                     self.merge_node(&local_child_node.guid, Some(local_child_node), None)?;
-                merged_node.merged_children.push(merged_child_node.into());
+                merged_node.merged_children.push(merged_child_node);
                 return Ok(true);
             }
         }
@@ -883,7 +883,7 @@ impl<'t> Merger<'t> {
                     // Flag the moved orphan for reupload.
                     let merge_state = MergeState::new(merged_orphan_node.merge_state);
                     merged_orphan_node.merge_state = merge_state;
-                    merged_node.merged_children.push(merged_orphan_node.into());
+                    merged_node.merged_children.push(merged_orphan_node);
                 },
             }
         }
@@ -921,7 +921,7 @@ impl<'t> Merger<'t> {
 
                     let merge_state = MergeState::new(merged_orphan_node.merge_state);
                     merged_orphan_node.merge_state = merge_state;
-                    merged_node.merged_children.push(merged_orphan_node.into());
+                    merged_node.merged_children.push(merged_orphan_node);
                 },
             }
         }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -34,11 +34,8 @@ impl Tree {
                deleted_guids: HashSet::new(), }
     }
 
-    pub fn deletions(&self) -> Vec<&str> {
-        self.deleted_guids
-            .iter()
-            .map(|guid| guid.as_ref())
-            .collect()
+    pub fn deletions<'t>(&'t self) -> impl Iterator<Item = &str> + 't {
+        self.deleted_guids.iter().map(move |guid| guid.as_ref())
     }
 
     pub fn is_deleted(&self, guid: &str) -> bool {
@@ -50,12 +47,11 @@ impl Tree {
         self.deleted_guids.insert(guid.into());
     }
 
-    pub fn guids(&self) -> Vec<&str> {
+    pub fn guids<'t>(&'t self) -> impl Iterator<Item = &str> + 't {
         self.index_by_guid
             .keys()
-            .map(|guid| guid.as_ref())
-            .chain(self.deleted_guids.iter().map(|guid| guid.as_ref()))
-            .collect()
+            .chain(self.deleted_guids.iter())
+            .map(move |guid| guid.as_ref())
     }
 
     pub fn node_for_guid<T>(&self, guid: T) -> Option<Node>
@@ -202,12 +198,11 @@ struct Entry {
 pub struct Node<'t>(&'t Tree, &'t Entry);
 
 impl<'t> Node<'t> {
-    pub fn children(&self) -> Vec<Node<'t>> {
+    pub fn children<'n>(&'n self) -> impl Iterator<Item = Node<'t>> + 'n {
         self.1
             .child_indices
             .iter()
-            .map(|index| self.0.node(*index))
-            .collect()
+            .map(move |index| self.0.node(*index))
     }
 
     pub fn parent(&self) -> Option<Node<'t>> {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -422,62 +422,16 @@ impl<'t> fmt::Display for MergeState<'t> {
 }
 
 /// Content info for an item in the local or remote tree. This is used to dedupe
-/// new local items to remote items that don't exist locally.
-#[derive(Debug)]
-pub struct Content {
-    pub title: String,
-    pub url_href: String,
-    pub position: i64,
-}
-
-/// A lookup key for a node and its content. This is used to match nodes with
-/// different GUIDs and similar content.
+/// new local items to remote items that don't exist locally, with different
+/// GUIDs and similar content.
 ///
 /// - Bookmarks must have the same title and URL.
 /// - Queries must have the same title and query URL.
 /// - Folders and livemarks must have the same title.
 /// - Separators must have the same position within their parents.
-#[derive(Debug)]
-pub struct ContentDupeKey<'t>(Node<'t>, &'t Content);
-
-impl<'t> ContentDupeKey<'t> {
-    pub fn new(node: Node<'t>, content: &'t Content) -> ContentDupeKey<'t> {
-        ContentDupeKey(node, content)
-    }
-}
-
-impl<'t> PartialEq for ContentDupeKey<'t> {
-    fn eq(&self, other: &ContentDupeKey) -> bool {
-        if self.0.kind != other.0.kind {
-            false
-        } else {
-            match self.0.kind {
-                Kind::Bookmark | Kind::Query => {
-                    self.1.title == other.1.title && self.1.url_href == other.1.url_href
-                },
-                Kind::Folder | Kind::Livemark => self.1.title == other.1.title,
-                Kind::Separator => self.1.position == other.1.position,
-            }
-        }
-    }
-}
-
-impl<'t> Eq for ContentDupeKey<'t> {}
-
-impl<'t> Hash for ContentDupeKey<'t> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.kind.hash(state);
-        match self.0.kind {
-            Kind::Bookmark | Kind::Query => {
-                self.1.title.hash(state);
-                self.1.url_href.hash(state);
-            },
-            Kind::Folder | Kind::Livemark => {
-                self.1.title.hash(state);
-            },
-            Kind::Separator => {
-                self.1.position.hash(state);
-            },
-        }
-    }
+#[derive(Debug, Eq, Hash, PartialEq)]
+pub enum Content {
+    Bookmark { title: String, url_href: String },
+    Folder { title: String },
+    Separator { position: i64 },
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -92,6 +92,7 @@ impl Tree {
     }
 }
 
+#[cfg(test)]
 impl PartialEq for Tree {
     fn eq(&self, other: &Tree) -> bool {
         if self.index_by_guid.len() != other.index_by_guid.len() {
@@ -137,8 +138,6 @@ impl PartialEq for Tree {
         true
     }
 }
-
-impl Eq for Tree {}
 
 impl<'t> From<MergedNode<'t>> for Tree {
     fn from(root: MergedNode<'t>) -> Self {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -241,7 +241,7 @@ impl<'t> fmt::Display for Node<'t> {
 #[derive(Debug, Eq, PartialEq)]
 pub struct Item {
     pub guid: String,
-    pub age: u64,
+    pub age: i64,
     pub kind: Kind,
     pub needs_merge: bool,
     pub is_syncable: bool,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -63,17 +63,17 @@ impl Tree {
 
     pub fn insert<T>(&mut self, parent_guid: T, item: Item)
         where T: AsRef<str> {
-        if self.index_by_guid.contains_key(&item.guid) {
-            panic!("Entry {} already exists in tree", &item.guid);
-        }
+        assert!(!self.index_by_guid.contains_key(&item.guid),
+                "Entry {} already exists in tree",
+                &item.guid);
         let child_index = self.entries.len();
         let (parent_index, level) = match self.index_by_guid.get(parent_guid.as_ref()) {
             Some(parent_index) => {
                 let parent = &mut self.entries[*parent_index];
-                if !parent.item.is_folder() {
-                    panic!("Can't insert {} into non-folder {}",
-                           &item.guid, &parent.item.guid);
-                }
+                assert!(parent.item.is_folder(),
+                        "Can't insert {} into non-folder {}",
+                        &item.guid,
+                        &parent.item.guid);
                 parent.child_indices.push(child_index);
                 (*parent_index, parent.level + 1)
             },

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -5,7 +5,6 @@
 use std::{cmp::{Eq, PartialEq},
           collections::{HashMap, HashSet},
           fmt,
-          hash::{Hash, Hasher},
           ops::Deref};
 
 /// A complete, rooted bookmark tree with tombstones.
@@ -160,14 +159,14 @@ impl<'t> From<MergedNode<'t>> for Tree {
             tree.insert(parent_guid, to_item(&node));
             node.merged_children
                 .into_iter()
-                .for_each(|merged_child_node| inflate(tree, &guid, *merged_child_node));
+                .for_each(|merged_child_node| inflate(tree, &guid, merged_child_node));
         }
 
         let guid = root.guid.clone();
         let mut tree = Tree::new(to_item(&root));
         root.merged_children
             .into_iter()
-            .for_each(|merged_child_node| inflate(&mut tree, &guid, *merged_child_node));
+            .for_each(|merged_child_node| inflate(&mut tree, &guid, merged_child_node));
         tree
     }
 }
@@ -315,7 +314,7 @@ impl fmt::Display for Kind {
 pub struct MergedNode<'t> {
     pub guid: String,
     pub merge_state: MergeState<'t>,
-    pub merged_children: Vec<Box<MergedNode<'t>>>,
+    pub merged_children: Vec<MergedNode<'t>>,
 }
 
 impl<'t> MergedNode<'t> {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -309,8 +309,8 @@ impl fmt::Display for Kind {
     }
 }
 
-/// A node in a merged bookmark tree. Holds the local node, remote node,
-/// merged children, and a merge state indicating which side to prefer.
+/// A merged bookmark node that indicates which side to prefer, and holds merged
+/// child nodes.
 #[derive(Debug)]
 pub struct MergedNode<'t> {
     pub guid: String,
@@ -373,9 +373,8 @@ impl fmt::Display for StructureState {
     }
 }
 
-/// The merge state indicates which node we should prefer when reconciling
-/// with Places. Recall that a merged node may point to a local node, remote
-/// node, or both.
+/// The merge state indicates which node we should prefer, local or remote, when
+/// resolving conflicts.
 #[derive(Clone, Copy, Debug)]
 pub struct MergeState<'t>(ValueState<'t>, StructureState);
 
@@ -384,20 +383,13 @@ impl<'t> MergeState<'t> {
     /// structure state. This could mean that the item doesn't exist on the
     /// server yet, or that it has newer local changes that we should
     /// upload.
-    ///
-    /// It's an error for a merged node to have a local merge state without a
-    /// local node. Deciding the value state for the merged node asserts
-    /// this.
     pub fn local(node: Node<'t>) -> MergeState<'t> {
         MergeState(ValueState::Local(node), StructureState::Local)
     }
 
-    /// A remote merge state means we should update Places with new value and
-    /// structure state from the mirror. The item might not exist locally yet,
-    /// or might have newer remote changes that we should apply.
-    ///
-    /// As with local, a merged node can't have a remote merge state without a
-    /// remote node.
+    /// A remote merge state means we should update the local value and
+    /// structure state. The item might not exist locally yet, or might have
+    /// newer remote changes that we should apply.
     pub fn remote(node: Node<'t>) -> MergeState<'t> {
         MergeState(ValueState::Remote(node), StructureState::Remote)
     }
@@ -407,8 +399,7 @@ impl<'t> MergeState<'t> {
     /// remotely deleted folder, or remote items out of a locally deleted
     /// folder.
     ///
-    /// Applying a new merged node bumps its local change counter, so that the
-    /// merged structure is reuploaded to the server.
+    /// New merged nodes should be reuploaded to the server.
     pub fn new(old: MergeState<'t>) -> MergeState<'t> {
         MergeState(old.0, StructureState::New)
     }
@@ -431,7 +422,7 @@ impl<'t> fmt::Display for MergeState<'t> {
 }
 
 /// Content info for an item in the local or remote tree. This is used to dedupe
-/// NEW local items to remote items that don't exist locally.
+/// new local items to remote items that don't exist locally.
 #[derive(Debug)]
 pub struct Content {
     pub title: String,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -3,79 +3,270 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std::{cmp::{Eq, PartialEq},
-          collections::HashSet,
+          collections::{HashMap, HashSet},
           fmt,
           hash::{Hash, Hasher},
-          iter};
+          ops::Deref};
 
-/// Synced item kinds. Each corresponds to a Sync record type.
-#[derive(Eq, Hash, PartialEq)]
-pub enum Kind {
-    Bookmark,
-    Query,
-    Folder,
-    Livemark,
-    Separator,
-}
-
-impl fmt::Display for Kind {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(match self {
-                        Kind::Bookmark => "Bookmark",
-                        Kind::Query => "Query",
-                        Kind::Folder => "Folder",
-                        Kind::Livemark => "Livemark",
-                        Kind::Separator => "Separator",
-                    })
-    }
-}
-
-/// A complete, rooted tree with tombstones.
+/// A complete, rooted bookmark tree with tombstones.
+///
+/// The tree stores bookmark nodes in a vector, and uses indices in the vector
+/// to identify parents and children. This makes traversal and lookup very
+/// efficient. Retrieving a node's parent takes one indexing operation,
+/// retrieving children takes one indexing operation per child, and retrieving a
+/// node by random GUID takes one hash map lookup and one indexing operation.
+#[derive(Debug)]
 pub struct Tree {
-    pub deleted_guids: HashSet<String>,
+    entries: Vec<Entry>,
+    index_by_guid: HashMap<String, usize>,
+    deleted_guids: HashSet<String>,
 }
 
 impl Tree {
+    /// Constructs a new rooted tree.
+    pub fn new(root: Item) -> Tree {
+        let mut index_by_guid = HashMap::new();
+        index_by_guid.insert(root.guid.to_string(), 0);
+        Tree { entries: vec![Entry { parent_index: None,
+                                     item: root,
+                                     level: 0,
+                                     child_indices: Vec::new(), }],
+               index_by_guid,
+               deleted_guids: HashSet::new(), }
+    }
+
+    pub fn deletions(&self) -> Vec<&str> {
+        self.deleted_guids
+            .iter()
+            .map(|guid| guid.as_ref())
+            .collect()
+    }
+
     pub fn is_deleted(&self, guid: &str) -> bool {
-        false
+        self.deleted_guids.contains(guid)
     }
 
-    pub fn node_for_guid(&self, guid: &str) -> Option<&Node> {
-        None
+    pub fn note_deleted<T>(&mut self, guid: T)
+        where T: Into<String> {
+        self.deleted_guids.insert(guid.into());
     }
 
-    pub fn parent_node_for(&self, child_node: &Node) -> &Node {
-        unimplemented!();
+    pub fn guids(&self) -> Vec<&str> {
+        self.index_by_guid
+            .keys()
+            .map(|guid| guid.as_ref())
+            .chain(self.deleted_guids.iter().map(|guid| guid.as_ref()))
+            .collect()
     }
 
-    pub fn guids(&self) -> impl Iterator<Item = &str> {
-        iter::empty::<&str>()
+    pub fn node_for_guid<T>(&self, guid: T) -> Option<Node>
+        where T: AsRef<str> {
+        self.index_by_guid
+            .get(guid.as_ref())
+            .map(|index| self.node(*index))
+    }
+
+    pub fn insert<T>(&mut self, parent_guid: T, item: Item)
+        where T: AsRef<str> {
+        if self.index_by_guid.contains_key(&item.guid) {
+            panic!("Entry {} already exists in tree", &item.guid);
+        }
+        let child_index = self.entries.len();
+        let (parent_index, level) = match self.index_by_guid.get(parent_guid.as_ref()) {
+            Some(parent_index) => {
+                let parent = &mut self.entries[*parent_index];
+                if !parent.item.is_folder() {
+                    panic!("Can't insert {} into non-folder {}",
+                           &item.guid, &parent.item.guid);
+                }
+                parent.child_indices.push(child_index);
+                (*parent_index, parent.level + 1)
+            },
+            None => panic!("Missing parent {} for {}", &item.guid, parent_guid.as_ref()),
+        };
+        self.index_by_guid
+            .insert(item.guid.to_string(), child_index);
+        self.entries.push(Entry { parent_index: Some(parent_index),
+                                  item,
+                                  level,
+                                  child_indices: Vec::new(), });
+    }
+
+    fn node(&self, index: usize) -> Node {
+        Node(self, &self.entries[index])
     }
 }
 
-/// A node in a local or remote bookmark tree.
-pub struct Node {
+impl PartialEq for Tree {
+    fn eq(&self, other: &Tree) -> bool {
+        if self.index_by_guid.len() != other.index_by_guid.len() {
+            return false;
+        }
+        for (guid, index) in &self.index_by_guid {
+            if let Some(other_index) = other.index_by_guid.get(guid) {
+                let entry = &self.entries[*index];
+                let other_entry = &other.entries[*other_index];
+                if entry.item != other_entry.item {
+                    return false;
+                }
+                match (entry.parent_index, other_entry.parent_index) {
+                    (Some(parent_index), Some(other_parent_index)) => {
+                        let parent_guid = &self.entries[parent_index].item.guid;
+                        let other_parent_guid = &other.entries[other_parent_index].item.guid;
+                        if parent_guid != other_parent_guid {
+                            return false;
+                        }
+                    },
+                    (None, None) => {},
+                    _ => return false,
+                };
+                let child_guids = entry.child_indices
+                                       .iter()
+                                       .map(|index| &self.entries[*index].item.guid);
+                let other_child_guids =
+                    other_entry.child_indices
+                               .iter()
+                               .map(|other_index| &other.entries[*other_index].item.guid);
+                if child_guids.ne(other_child_guids) {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+        for other_guid in other.index_by_guid.keys() {
+            if !self.index_by_guid.contains_key(other_guid) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl Eq for Tree {}
+
+impl<'t> From<MergedNode<'t>> for Tree {
+    fn from(root: MergedNode<'t>) -> Self {
+        fn to_item<'t>(node: &MergedNode<'t>) -> Item {
+            let value_state = node.merge_state.value();
+            let decided_value = value_state.node();
+            let mut item = Item::new(&node.guid, decided_value.kind);
+            item.age = decided_value.age;
+            item
+        }
+
+        fn inflate<'t>(tree: &mut Tree, parent_guid: &str, node: MergedNode<'t>) {
+            let guid = node.guid.clone();
+            tree.insert(parent_guid, to_item(&node));
+            node.merged_children
+                .into_iter()
+                .for_each(|merged_child_node| inflate(tree, &guid, *merged_child_node));
+        }
+
+        let guid = root.guid.clone();
+        let mut tree = Tree::new(to_item(&root));
+        root.merged_children
+            .into_iter()
+            .for_each(|merged_child_node| inflate(&mut tree, &guid, *merged_child_node));
+        tree
+    }
+}
+
+/// An entry wraps a tree item with references to its parent and children, which
+/// index into the tree's `entries` vector. This indirection exists because
+/// Rust is more strict about ownership of parents and children.
+///
+/// For example, we can't have entries own their children without sacrificing
+/// fast random lookup, because we'd need to store references to the entries
+/// in the lookup map, but a struct can't hold references into itself.
+///
+/// Similarly, we can't have entries hold `Weak` pointers to `Rc` entries for
+/// the parent and children, because we need to update the parent when we insert
+/// a new node, but `Rc` won't hand us a mutable reference to the entry as long
+/// as it has outstanding `Weak` pointers.
+///
+/// We *could* use GUIDs instead of indices, and store the entries in a
+/// `HashMap<String, Entry>`, but that's inefficient: we'd need to store N
+/// copies of the GUID for parent and child lookups, and retrieving children
+/// would take one hash map lookup *per child*.
+#[derive(Debug)]
+struct Entry {
+    parent_index: Option<usize>,
+    item: Item,
+    level: u64,
+    child_indices: Vec<usize>,
+}
+
+/// A convenience wrapper around `Entry` that dereferences to the containing
+/// item, and follows indices for parents and children.
+#[derive(Clone, Copy, Debug)]
+pub struct Node<'t>(&'t Tree, &'t Entry);
+
+impl<'t> Node<'t> {
+    pub fn children(&self) -> Vec<Node<'t>> {
+        self.1
+            .child_indices
+            .iter()
+            .map(|index| self.0.node(*index))
+            .collect()
+    }
+
+    pub fn parent(&self) -> Option<Node<'t>> {
+        self.1
+            .parent_index
+            .as_ref()
+            .map(|index| self.0.node(*index))
+    }
+
+    pub fn level(&self) -> u64 {
+        self.1.level
+    }
+}
+
+impl<'t> Deref for Node<'t> {
+    type Target = Item;
+
+    fn deref(&self) -> &Item {
+        &self.1.item
+    }
+}
+
+impl<'t> fmt::Display for Node<'t> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.1.item.fmt(f)
+    }
+}
+
+/// An item in a local or remote bookmark tree.
+#[derive(Debug, Eq, PartialEq)]
+pub struct Item {
     pub guid: String,
     pub age: u64,
     pub kind: Kind,
     pub needs_merge: bool,
-    pub level: u64,
     pub is_syncable: bool,
-    pub children: Vec<Box<Node>>,
 }
 
-impl Node {
+impl Item {
+    pub fn new(guid: &str, kind: Kind) -> Item {
+        Item { guid: guid.to_string(),
+               kind,
+               age: 0,
+               needs_merge: false,
+               is_syncable: true, }
+    }
+
     #[inline]
     pub fn is_folder(&self) -> bool {
         self.kind == Kind::Folder
     }
 
     #[inline]
-    pub fn newer_than(&self, other: &Node) -> bool {
+    pub fn newer_than(&self, other: &Item) -> bool {
         self.age < other.age
     }
 
-    pub fn has_compatible_kind(&self, remote_node: &Node) -> bool {
+    pub fn has_compatible_kind(&self, remote_node: &Item) -> bool {
         match (&self.kind, &remote_node.kind) {
             // Bookmarks and queries are interchangeable, as simply changing the URL
             // can cause it to flip kinds.
@@ -91,7 +282,7 @@ impl Node {
     }
 }
 
-impl fmt::Display for Node {
+impl fmt::Display for Item {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let info = if self.needs_merge {
             format!("({}; Age = {}ms; Unmerged", self.kind, self.age)
@@ -102,26 +293,34 @@ impl fmt::Display for Node {
     }
 }
 
+/// Synced item kinds. Each corresponds to a Sync record type.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum Kind {
+    Bookmark,
+    Query,
+    Folder,
+    Livemark,
+    Separator,
+}
+
+impl fmt::Display for Kind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
 /// A node in a merged bookmark tree. Holds the local node, remote node,
 /// merged children, and a merge state indicating which side to prefer.
+#[derive(Debug)]
 pub struct MergedNode<'t> {
     pub guid: String,
-    pub local_node: Option<&'t Node>,
-    pub remote_node: Option<&'t Node>,
-    pub merge_state: MergeState,
+    pub merge_state: MergeState<'t>,
     pub merged_children: Vec<Box<MergedNode<'t>>>,
 }
 
 impl<'t> MergedNode<'t> {
-    pub fn new(guid: String,
-               local_node: Option<&'t Node>,
-               remote_node: Option<&'t Node>,
-               merge_state: MergeState)
-               -> MergedNode<'t>
-    {
+    pub fn new(guid: String, merge_state: MergeState<'t>) -> MergedNode<'t> {
         MergedNode { guid,
-                     local_node,
-                     remote_node,
                      merge_state,
                      merged_children: Vec::new(), }
     }
@@ -133,22 +332,31 @@ impl<'t> fmt::Display for MergedNode<'t> {
     }
 }
 
-#[derive(Clone)]
-pub enum ValueState {
-    Local,
-    Remote,
+#[derive(Clone, Copy, Debug)]
+pub enum ValueState<'t> {
+    Local(Node<'t>),
+    Remote(Node<'t>),
 }
 
-impl fmt::Display for ValueState {
+impl<'t> ValueState<'t> {
+    pub fn node(&self) -> &Node<'t> {
+        match self {
+            ValueState::Local(node) => node,
+            ValueState::Remote(node) => node,
+        }
+    }
+}
+
+impl<'t> fmt::Display for ValueState<'t> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(match self {
-                        ValueState::Local => "Value: Local",
-                        ValueState::Remote => "Value: Remote",
+                        ValueState::Local(_) => "Value: Local",
+                        ValueState::Remote(_) => "Value: Remote",
                     })
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug)]
 pub enum StructureState {
     Local,
     Remote,
@@ -168,10 +376,10 @@ impl fmt::Display for StructureState {
 /// The merge state indicates which node we should prefer when reconciling
 /// with Places. Recall that a merged node may point to a local node, remote
 /// node, or both.
-#[derive(Clone)]
-pub struct MergeState(ValueState, StructureState);
+#[derive(Clone, Copy, Debug)]
+pub struct MergeState<'t>(ValueState<'t>, StructureState);
 
-impl MergeState {
+impl<'t> MergeState<'t> {
     /// A local merge state means no changes: we keep the local value and
     /// structure state. This could mean that the item doesn't exist on the
     /// server yet, or that it has newer local changes that we should
@@ -180,8 +388,8 @@ impl MergeState {
     /// It's an error for a merged node to have a local merge state without a
     /// local node. Deciding the value state for the merged node asserts
     /// this.
-    pub fn local() -> MergeState {
-        MergeState(ValueState::Local, StructureState::Local)
+    pub fn local(node: Node<'t>) -> MergeState<'t> {
+        MergeState(ValueState::Local(node), StructureState::Local)
     }
 
     /// A remote merge state means we should update Places with new value and
@@ -190,8 +398,8 @@ impl MergeState {
     ///
     /// As with local, a merged node can't have a remote merge state without a
     /// remote node.
-    pub fn remote() -> MergeState {
-        MergeState(ValueState::Remote, StructureState::Remote)
+    pub fn remote(node: Node<'t>) -> MergeState<'t> {
+        MergeState(ValueState::Remote(node), StructureState::Remote)
     }
 
     /// Takes an existing value state, and a new structure state. We use the new
@@ -201,12 +409,22 @@ impl MergeState {
     ///
     /// Applying a new merged node bumps its local change counter, so that the
     /// merged structure is reuploaded to the server.
-    pub fn new(old: MergeState) -> MergeState {
+    pub fn new(old: MergeState<'t>) -> MergeState<'t> {
         MergeState(old.0, StructureState::New)
+    }
+
+    #[inline]
+    pub fn value(&self) -> ValueState {
+        self.0
+    }
+
+    #[inline]
+    pub fn structure(&self) -> StructureState {
+        self.1
     }
 }
 
-impl fmt::Display for MergeState {
+impl<'t> fmt::Display for MergeState<'t> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}; {}", self.0, self.1)
     }
@@ -214,6 +432,7 @@ impl fmt::Display for MergeState {
 
 /// Content info for an item in the local or remote tree. This is used to dedupe
 /// NEW local items to remote items that don't exist locally.
+#[derive(Debug)]
 pub struct Content {
     pub title: String,
     pub url_href: String,
@@ -227,10 +446,11 @@ pub struct Content {
 /// - Queries must have the same title and query URL.
 /// - Folders and livemarks must have the same title.
 /// - Separators must have the same position within their parents.
-pub struct ContentDupeKey<'t>(&'t Node, &'t Content);
+#[derive(Debug)]
+pub struct ContentDupeKey<'t>(Node<'t>, &'t Content);
 
 impl<'t> ContentDupeKey<'t> {
-    pub fn new(node: &'t Node, content: &'t Content) -> ContentDupeKey<'t> {
+    pub fn new(node: Node<'t>, content: &'t Content) -> ContentDupeKey<'t> {
         ContentDupeKey(node, content)
     }
 }


### PR DESCRIPTION
It's a Rusty bookmark party! 🎉 📚 🔖 🦀 

* Implement `Tree::insert`.
* Overhaul the `Tree` interface. I played around with going a step further and making the tree generic for the item and GUID type, instead of restricting to just `Item` and `String`...but that got unwieldy with `&str` vs. `String`, and then I added `Eq`, which needed yet another trait bound. 😕 At that point, it didn't seem worthwhile.
* Simplify `MergedNode`. We can use the `ValueState` enum to store the preferred node, and statically assert that, for example, we don't have a `Local` state without a local node. ✨ 
* Clean up comments that still mention Places, and fix some review nits.
* Add a test for the (in)famous "add to folder on one side, delete folder on the other" scenario. 😄

@thomcc, it would be great if you could take a look when you have cycles. Thanks!