### PR TITLE
Don't allow merging folders and livemarks

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,7 @@
 use std::{error, fmt, result};
 
 use guid::Guid;
+use tree::Kind;
 
 pub type Result<T> = result::Result<T, Error>;
 
@@ -43,7 +44,7 @@ impl fmt::Display for Error {
 
 #[derive(Debug)]
 pub enum ErrorKind {
-    ConsistencyError(&'static str),
+    MismatchedKindError(Kind, Kind),
     DuplicateItemError(Guid),
     InvalidParentError(Guid, Guid),
     MissingParentError(Guid, Guid),
@@ -52,7 +53,10 @@ pub enum ErrorKind {
 impl fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ErrorKind::ConsistencyError(err) => write!(f, "{}", err),
+            ErrorKind::MismatchedKindError(local_kind, remote_kind) => {
+                write!(f, "Can't merge local kind {} and remote kind {}",
+                       local_kind, remote_kind)
+            },
             ErrorKind::DuplicateItemError(guid) => {
                 write!(f, "Item {} already exists in tree", guid)
             },

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -325,11 +325,6 @@ impl Item {
             // can cause it to flip kinds.
             (Kind::Bookmark, Kind::Query) => true,
             (Kind::Query, Kind::Bookmark) => true,
-
-            // A local folder can become a livemark, as the remote may have synced
-            // as a folder before the annotation was added. However, we don't allow
-            // a local livemark to "downgrade" to a folder. See bug 632287.
-            (Kind::Folder, Kind::Livemark) => true,
             (local_kind, remote_kind) => local_kind == remote_kind,
         }
     }


### PR DESCRIPTION
This won't go well if the folder somehow has children on one side. (Livemarks haven't had real children for a while, as seen in [bug 632287](https://bugzilla.mozilla.org/show_bug.cgi?id=632287), but the folder can still be modified locally). Since we're removing livemarks in [bug 1477667](https://bugzilla.mozilla.org/show_bug.cgi?id=1477667), we can probably remove this entirely instead of adding complexity to the merger.