### PR TITLE
Set up Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,36 @@
 language: rust
 rust:
   - nightly
-sudo: false
+dist: trusty
+sudo: required
+
+addons:
+  apt:
+    packages:
+      - libcurl4-openssl-dev
+      - libelf-dev
+      - libdw-dev
+      - cmake
+      - gcc
+      - binutils-dev
+      - libiberty-dev
+      - moreutils
+
+cache:
+  cargo: true
+  directories:
+    - $HOME/.src
+
+env:
+  global:
+    - KCOV_VERSION=36
+    - PATH=$HOME/.local/bin:$PATH
+
+before_install:
+  - ./.travis/before_install.sh
+
+install:
+  - ./.travis/install.sh
 
 before_script:
   - rustup component add rustfmt-preview
@@ -9,3 +38,6 @@ before_script:
 script:
   - cargo build
   - cargo test
+
+after_success:
+  - ./.travis/after_success.sh

--- a/.travis/after_success.sh
+++ b/.travis/after_success.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+for file in target/debug/vellum-*[^\.d]; do
+  mkdir -p "target/cov/$(basename $file)"
+  kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"
+done
+bash <(curl -s https://codecov.io/bash)

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+if ! [ -f $HOME/.src/kcov-$KCOV_VERSION.tar.gz ]; then
+  wget -O $HOME/.src/kcov-$KCOV_VERSION.tar.gz https://github.com/SimonKagstrom/kcov/archive/v$KCOV_VERSION.tar.gz
+fi

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+mkdir $HOME/.deps
+pushd $HOME/.deps
+
+tar xzf $HOME/.src/kcov-$KCOV_VERSION.tar.gz
+pushd kcov-$KCOV_VERSION
+mkdir build
+pushd build
+chronic cmake -DCMAKE_INSTALL_PREFIX=$HOME/.local ..
+chronic make
+chronic make install
+popd
+popd
+
+popd


### PR DESCRIPTION
We need to use `sudo: required` for now, to work around travis-ci/travis-ci#9061. 🔧:shipit: