### PR TITLE
Ensure we set upload flags correctly for merged items

### DIFF
--- a/src/merge.rs
+++ b/src/merge.rs
@@ -285,7 +285,7 @@ impl<'t> Merger<'t> {
                 (true, false) => {
                     // The node was changed locally since the last sync, but not
                     // remotely. Keep the local state.
-                    MergedNode::new(remote_node.guid.clone(), remote_node, MergeState::Remote)
+                    MergedNode::new(remote_node.guid.clone(), local_node, MergeState::Local)
                 },
                 (false, true) => {
                     // The node was changed remotely, but not locally. Take the
@@ -1473,7 +1473,7 @@ mod tests {
 
         let expected_tree = nodes!({
             ("menu________", Folder, {
-                ("folderAAAAAA", Folder[needs_merge = true], {
+                ("folderAAAAAA", Folder[needs_merge = true, age = 10], {
                     ("bookmarkCCCC", Bookmark)
                 }),
                 ("folderDDDDDD", Folder[needs_merge = true, age = 5], {
@@ -1990,7 +1990,7 @@ mod tests {
                 ("bookmarkFFFF", Bookmark[needs_merge = true])
             }),
             ("toolbar_____", Folder[needs_merge = true], {
-                ("bookmarkDDDD", Bookmark[age = 5]),
+                ("bookmarkDDDD", Bookmark),
                 ("bookmarkBBBB", Bookmark[age = 5])
             })
         }).into_tree().unwrap();

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -273,8 +273,8 @@ impl<'t> Merger<'t> {
         } else {
             match (local_node.needs_merge, remote_node.needs_merge) {
                 (true, true) => {
-                    // The node was changed locally and remotely since the last
-                    // sync. Use the timestamp to decide which is newer.
+                    // The item changed locally and remotely. Use the timestamp
+                    // to decide which is newer.
                     if local_node.newer_than(&remote_node) {
                         MergedNode::new(remote_node.guid.clone(),
                                         MergeState::Local { local_node, remote_node: Some(remote_node) })
@@ -284,20 +284,21 @@ impl<'t> Merger<'t> {
                     }
                 },
                 (true, false) => {
-                    // The node was changed locally since the last sync, but not
-                    // remotely. Keep the local state.
+                    // The item changed locally, but not remotely. Keep the
+                    // local state.
                     MergedNode::new(remote_node.guid.clone(),
                                     MergeState::Local { local_node, remote_node: Some(remote_node) })
                 },
                 (false, true) => {
-                    // The node was changed remotely, but not locally. Take the
+                    // The item changed remotely, but not locally. Take the
                     // remote state.
                     MergedNode::new(remote_node.guid.clone(),
                                     MergeState::Remote { local_node: Some(local_node), remote_node })
                 },
                 (false, false) => {
+                  // The item is unchanged on both sides. Keep the local state.
                     MergedNode::new(remote_node.guid.clone(),
-                                    MergeState::Remote { local_node: Some(local_node), remote_node })
+                                    MergeState::Local { local_node, remote_node: Some(remote_node) })
                 },
             }
         };
@@ -1420,9 +1421,9 @@ mod tests {
             ("menu________", Folder[needs_merge = true], {
                 // The server has an older menu, so we should use the local order (C A B)
                 // as the base, then append (I J).
-                ("bookmarkCCCC", Bookmark[age = 5]),
-                ("bookmarkAAAA", Bookmark[age = 5]),
-                ("bookmarkBBBB", Bookmark[age = 5]),
+                ("bookmarkCCCC", Bookmark),
+                ("bookmarkAAAA", Bookmark),
+                ("bookmarkBBBB", Bookmark),
                 ("bookmarkIIII", Bookmark),
                 ("bookmarkJJJJ", Bookmark)
             }),

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1271,7 +1271,7 @@ mod tests {
         assert!(merger.subsumes(&local_tree));
         assert!(merger.subsumes(&remote_tree));
 
-        let expected_tree = nodes!({
+        let expected_tree = nodes!(ROOT_GUID, Folder[needs_merge = true], {
             ("unfiled_____", Folder, {
                 ("folderBBBBBB", Folder, {
                     ("bookmarkDDDD", Bookmark),
@@ -1280,11 +1280,11 @@ mod tests {
                 })
             }),
             ("toolbar_____", Folder, {
-                ("folderAAAAAA", Folder, {
+                ("folderAAAAAA", Folder[needs_merge = true], {
                     ("bookmarkEEEE", Bookmark)
                 })
             }),
-            ("menu________", Folder, {
+            ("menu________", Folder[needs_merge = true], {
                 ("bookmarkFFFF", Bookmark)
             })
         }).into_tree().unwrap();
@@ -1397,7 +1397,7 @@ mod tests {
         assert!(merger.subsumes(&remote_tree));
 
         let expected_tree = nodes!({
-            ("menu________", Folder, {
+            ("menu________", Folder[needs_merge = true], {
                 // The server has an older menu, so we should use the local order (C A B)
                 // as the base, then append (I J).
                 ("bookmarkCCCC", Bookmark[age = 5]),
@@ -1406,7 +1406,7 @@ mod tests {
                 ("bookmarkIIII", Bookmark),
                 ("bookmarkJJJJ", Bookmark)
             }),
-            ("toolbar_____", Folder[age = 5], {
+            ("toolbar_____", Folder[needs_merge = true, age = 5], {
                 // The server has a newer toolbar, so we should use the remote order (F D E)
                 // as the base, then append (G H).
                 ("bookmarkFFFF", Bookmark),
@@ -1473,10 +1473,10 @@ mod tests {
 
         let expected_tree = nodes!({
             ("menu________", Folder, {
-                ("folderAAAAAA", Folder, {
+                ("folderAAAAAA", Folder[needs_merge = true], {
                     ("bookmarkCCCC", Bookmark)
                 }),
-                ("folderDDDDDD", Folder[age = 5], {
+                ("folderDDDDDD", Folder[needs_merge = true, age = 5], {
                     ("bookmarkEEEE", Bookmark[age = 5]),
                     ("bookmarkBBBB", Bookmark)
                 })
@@ -1537,7 +1537,7 @@ mod tests {
                 ("bookmarkCCCC", Bookmark)
             }),
             ("toolbar_____", Folder, {
-                ("folderAAAAAA", Folder, {
+                ("folderAAAAAA", Folder[needs_merge = true], {
                     // We can guarantee child order (B E D), since we always walk remote
                     // children first, and the remote folder A record is newer than the
                     // local folder. If the local folder were newer, the order would be
@@ -1618,17 +1618,17 @@ mod tests {
 
         let expected_tree = nodes!({
             ("toolbar_____", Folder, {
-                ("folderAAAAAA", Folder, {
+                ("folderAAAAAA", Folder[needs_merge = true], {
                     // B was deleted remotely, so F moved to A, the closest
                     // surviving parent.
-                    ("bookmarkFFFF", Bookmark)
+                    ("bookmarkFFFF", Bookmark[needs_merge = true])
                 })
             }),
             ("menu________", Folder, {
                 ("folderCCCCCC", Folder, {
-                    ("folderDDDDDD", Folder, {
+                    ("folderDDDDDD", Folder[needs_merge = true], {
                         // E was deleted locally, so G moved to D.
-                        ("bookmarkGGGG", Bookmark)
+                        ("bookmarkGGGG", Bookmark[needs_merge = true])
                     })
                 })
             })
@@ -1713,14 +1713,14 @@ mod tests {
 
         let expected_tree = nodes!({
             ("toolbar_____", Folder, {
-                ("folderAAAAAA", Folder, {
-                    ("bookmarkFFFF", Bookmark)
+                ("folderAAAAAA", Folder[needs_merge = true], {
+                    ("bookmarkFFFF", Bookmark[needs_merge = true])
                 })
             }),
             ("menu________", Folder, {
                 ("folderCCCCCC", Folder, {
-                    ("folderDDDDDD", Folder, {
-                        ("bookmarkGGGG", Bookmark)
+                    ("folderDDDDDD", Folder[needs_merge = true], {
+                        ("bookmarkGGGG", Bookmark[needs_merge = true])
                     })
                 })
             })
@@ -1790,10 +1790,10 @@ mod tests {
         assert!(merger.subsumes(&remote_tree));
 
         let expected_tree = nodes!({
-            ("menu________", Folder, {
+            ("menu________", Folder[needs_merge = true], {
                 ("bookmarkAAAA", Bookmark),
-                ("bookmarkFFFF", Bookmark),
-                ("bookmarkGGGG", Bookmark)
+                ("bookmarkFFFF", Bookmark[needs_merge = true]),
+                ("bookmarkGGGG", Bookmark[needs_merge = true])
             })
         }).into_tree().unwrap();
         let expected_deletions = vec![
@@ -1904,15 +1904,15 @@ mod tests {
         assert!(merger.subsumes(&local_tree));
         assert!(merger.subsumes(&remote_tree));
 
-        let expected_tree = nodes!({
-            ("menu________", Folder, {
+        let expected_tree = nodes!(ROOT_GUID, Folder[needs_merge = true], {
+            ("menu________", Folder[needs_merge = true], {
                 ("bookmarkBBBB", Bookmark),
                 ("bookmarkEEEE", Bookmark)
             }),
             ("unfiled_____", Folder, {
                 ("bookmarkCCCC", Bookmark)
             }),
-            ("mobile______", Folder, {
+            ("mobile______", Folder[needs_merge = true], {
                 ("bookmarkFFFF", Bookmark)
             })
         }).into_tree().unwrap();
@@ -1985,11 +1985,11 @@ mod tests {
         assert!(merger.subsumes(&remote_tree));
 
         let expected_tree = nodes!({
-            ("menu________", Folder, {
-                ("bookmarkEEEE", Bookmark),
-                ("bookmarkFFFF", Bookmark)
+            ("menu________", Folder[needs_merge = true], {
+                ("bookmarkEEEE", Bookmark[needs_merge = true]),
+                ("bookmarkFFFF", Bookmark[needs_merge = true])
             }),
-            ("toolbar_____", Folder, {
+            ("toolbar_____", Folder[needs_merge = true], {
                 ("bookmarkDDDD", Bookmark[age = 5]),
                 ("bookmarkBBBB", Bookmark[age = 5])
             })
@@ -2062,7 +2062,7 @@ mod tests {
         assert!(merger.subsumes(&remote_tree));
 
         let expected_tree = nodes!({
-            ("menu________", Folder, {
+            ("menu________", Folder[needs_merge = true], {
                 ("bookmarkAAAA", Bookmark),
                 ("bookmarkAAA4", Bookmark),
                 ("bookmarkAAA3", Bookmark),
@@ -2179,7 +2179,7 @@ mod tests {
 
         let expected_tree = nodes!({
             ("menu________", Folder[age = 5], {
-                ("folderAAAAAA", Folder, {
+                ("folderAAAAAA", Folder[needs_merge = true], {
                     ("bookmarkBBBB", Bookmark[age = 10]),
                     ("bookmarkCCC1", Bookmark),
                     ("bookmarkCCCC", Bookmark[age = 5])
@@ -2291,7 +2291,7 @@ mod tests {
 
         let expected_tree = nodes!({
             ("menu________", Folder, {
-                ("folderAAAAA1", Folder, {
+                ("folderAAAAA1", Folder[needs_merge = true], {
                     ("bookmarkBBB1", Bookmark),
                     ("bookmarkCCCC", Bookmark[age = 10])
                 }),
@@ -2340,7 +2340,7 @@ mod tests {
         assert!(merger.subsumes(&local_tree));
         assert!(merger.subsumes(&remote_tree));
 
-        let expected_tree = Tree::default();
+        let expected_tree = nodes!(ROOT_GUID, Folder[needs_merge = true]).into_tree().unwrap();
         let expected_deletions = vec![
             "folderLEFTPC",
             "folderLEFTPF",
@@ -2424,13 +2424,13 @@ mod tests {
         assert!(merger.subsumes(&local_tree));
         assert!(merger.subsumes(&remote_tree));
 
-        let expected_tree = nodes!({
-            ("unfiled_____", Folder, {
-                ("bookmarkJJJJ", Bookmark),
+        let expected_tree = nodes!(ROOT_GUID, Folder[needs_merge = true], {
+            ("unfiled_____", Folder[needs_merge = true], {
+                ("bookmarkJJJJ", Bookmark[needs_merge = true]),
                 ("bookmarkGGGG", Bookmark)
             }),
-            ("menu________", Folder, {
-                ("bookmarkBBBB", Bookmark)
+            ("menu________", Folder[needs_merge = true], {
+                ("bookmarkBBBB", Bookmark[needs_merge = true])
             })
         }).into_tree().unwrap();
         let expected_deletions = vec![
@@ -2714,11 +2714,11 @@ mod tests {
         assert!(merger.subsumes(&remote_tree));
 
         let expected_tree = nodes!({
-            ("toolbar_____", Folder[age = 5], {
+            ("toolbar_____", Folder[needs_merge = true, age = 5], {
                 ("!@#$%^", Bookmark[age = 5]),
                 ("", Bookmark[age = 5])
             }),
-            ("menu________", Folder, {
+            ("menu________", Folder[needs_merge = true], {
                 ("bookmarkAAAA", Bookmark),
                 ("bookmarkBBBB", Bookmark),
                 ("shortGUID", Bookmark),

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -380,6 +380,10 @@ impl<'t> MergedNode<'t> {
         fn to_item<'t>(merged_node: &MergedNode<'t>) -> Item {
             let mut item = Item::new(merged_node.guid.clone(), merged_node.node.kind);
             item.age = merged_node.node.age;
+            item.needs_merge = match merged_node.merge_state {
+                MergeState::Local | MergeState::Remote => false,
+                _ => true,
+            };
             item
         }
 


### PR DESCRIPTION
The way we flag new and merged local items for upload is a [bit of a mess](https://bugzilla.mozilla.org/show_bug.cgi?id=1496878). 🌪 This likely explains why we're seeing more `parentid` mismatches for the new bookmarks engine on Desktop, too.

Previously, when we preferred a local move over a remote move, we flagged the _parent_ for reupload, but not the _child_. Older Desktops and Android use the child's `parentid` to determine the correct parent, not the parent's `children`, and iOS expects the two to match. Desktop accidentally did the right thing in some cases because we didn't reset `needs_merge` for newer local values. However, if we _did_ reset the flag, we'd update the new parents, but not the child...meaning the child on the server would end up with a stale `parentid`, even if it was flagged correctly before merging. Oops. 😬

I also took the chance to simplify Sync change tracking for uploads. Now, all merged nodes with a `LocalWithNewStructure` or `RemoteWithNewStructure` state should be uploaded, and all others shouldn't.