### PR TITLE
Add an "unchanged" merge state

### DIFF
--- a/src/merge.rs
+++ b/src/merge.rs
@@ -637,7 +637,7 @@ impl<'t> Merger<'t> {
         match (local_node.needs_merge, remote_node.needs_merge) {
             (true, true) => {
                 // The item changed locally and remotely.
-                if local_node.newer_than(&remote_node) {
+                if local_node.age < remote_node.age {
                     // The local change is newer, so merge local children first,
                     // followed by remaining unmerged remote children.
                     (ConflictResolution::Local, ConflictResolution::Local)
@@ -694,10 +694,10 @@ impl<'t> Merger<'t> {
                 let latest_local_age = local_child_node.age.min(local_parent_node.age);
                 let latest_remote_age = remote_child_node.age.min(remote_parent_node.age);
 
-                if latest_remote_age <= latest_local_age {
-                    ConflictResolution::Remote
-                } else {
+                if latest_local_age < latest_remote_age {
                     ConflictResolution::Local
+                } else {
+                    ConflictResolution::Remote
                 }
             },
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -213,7 +213,7 @@ impl<'t> Merger<'t> {
         self.merged_guids.insert(local_node.guid.clone());
 
         let mut merged_node = MergedNode::new(local_node.guid.clone(),
-                                              MergeState::local(local_node));
+                                              MergeState::Local(local_node));
         if local_node.is_folder() {
             // The local folder doesn't exist remotely, but its children might, so
             // we still need to recursively walk and merge them. This method will
@@ -235,7 +235,7 @@ impl<'t> Merger<'t> {
         self.merged_guids.insert(remote_node.guid.clone());
 
         let mut merged_node = MergedNode::new(remote_node.guid.clone(),
-                                              MergeState::remote(remote_node));
+                                              MergeState::Remote(remote_node));
         if remote_node.is_folder() {
             // As above, a remote folder's children might still exist locally, so we
             // need to merge them and update the merge state from remote to new if
@@ -277,10 +277,10 @@ impl<'t> Merger<'t> {
 
         let mut merged_node = MergedNode::new(remote_node.guid.clone(), match item {
             ConflictResolution::Local => {
-                MergeState::Local { local_node, remote_node: Some(remote_node) }
+                MergeState::Local(local_node)
             },
             ConflictResolution::Remote => {
-                MergeState::Remote { local_node: Some(local_node), remote_node }
+                MergeState::Remote(remote_node)
             },
             ConflictResolution::Unchanged => {
                 MergeState::Unchanged { local_node, remote_node }
@@ -1406,9 +1406,9 @@ mod tests {
             ("menu________", Folder[needs_merge = true], {
                 // The server has an older menu, so we should use the local order (C A B)
                 // as the base, then append (I J).
-                ("bookmarkCCCC", Bookmark[age = 5]),
-                ("bookmarkAAAA", Bookmark[age = 5]),
-                ("bookmarkBBBB", Bookmark[age = 5]),
+                ("bookmarkCCCC", Bookmark),
+                ("bookmarkAAAA", Bookmark),
+                ("bookmarkBBBB", Bookmark),
                 ("bookmarkIIII", Bookmark),
                 ("bookmarkJJJJ", Bookmark)
             }),

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -314,11 +314,6 @@ impl Item {
         self.kind == Kind::Folder
     }
 
-    #[inline]
-    pub fn newer_than(&self, other: &Item) -> bool {
-        self.age < other.age
-    }
-
     pub fn has_compatible_kind(&self, remote_node: &Item) -> bool {
         match (&self.kind, &remote_node.kind) {
             // Bookmarks and queries are interchangeable, as simply changing the URL

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -379,9 +379,9 @@ impl<'t> MergedNode<'t> {
     /// Indicates whether the merged item should be (re)uploaded to the server.
     pub fn needs_upload(&self) -> bool {
         match self.merge_state {
-            MergeState::Local { .. }
-            | MergeState::LocalWithNewStructure { .. }
-            | MergeState::RemoteWithNewStructure { .. } => true,
+            MergeState::Local(_)
+            | MergeState::LocalWithNewStructure(_)
+            | MergeState::RemoteWithNewStructure(_) => true,
             _ => false,
         }
     }
@@ -393,8 +393,8 @@ impl<'t> MergedNode<'t> {
             let mut item = Item::new(merged_node.guid.clone(), node.kind);
             item.age = node.age;
             item.needs_merge = match merged_node.merge_state {
-                MergeState::Local { .. }
-                | MergeState::Remote { .. }
+                MergeState::Local(_)
+                | MergeState::Remote(_)
                 | MergeState::Unchanged { .. } => false,
                 _ => true,
             };
@@ -446,11 +446,11 @@ impl<'t> MergedNode<'t> {
 
     fn node(&self) -> Node {
         match self.merge_state {
-            MergeState::Local { local_node, .. } => local_node,
-            MergeState::Remote { remote_node, .. } => remote_node,
-            MergeState::LocalWithNewStructure { local_node, .. } => local_node,
-            MergeState::RemoteWithNewStructure { remote_node, .. } => remote_node,
-            MergeState::Unchanged { remote_node, .. } => remote_node,
+            MergeState::Local(node) => node,
+            MergeState::Remote(node) => node,
+            MergeState::LocalWithNewStructure(node) => node,
+            MergeState::RemoteWithNewStructure(node) => node,
+            MergeState::Unchanged { local_node, .. } => local_node,
         }
     }
 }
@@ -469,49 +469,41 @@ pub enum MergeState<'t> {
     /// structure state. This could mean that the item doesn't exist on the
     /// server yet, or that it has newer local changes that we should
     /// upload.
-    Local { local_node: Node<'t>, remote_node: Option<Node<'t>> },
+    Local(Node<'t>),
 
     /// A remote merge state means we should update the local value and
     /// structure state. The item might not exist locally yet, or might have
     /// newer remote changes that we should apply.
-    Remote { local_node: Option<Node<'t>>, remote_node: Node<'t> },
+    Remote(Node<'t>),
 
     /// A local merge state with new structure means we should prefer the local
     /// value state, and upload the new structure state to the server. We use
     /// new structure states to resolve conflicts caused by moving local items
     /// out of a remotely deleted folder, or remote items out of a locally
     /// deleted folder.
-    LocalWithNewStructure { local_node: Node<'t>, remote_node: Option<Node<'t>> },
+    LocalWithNewStructure(Node<'t>),
 
     /// A remote merge state with new structure means we should prefer the
     /// remote value and reupload the new structure.
-    RemoteWithNewStructure { local_node: Option<Node<'t>>, remote_node: Node<'t> },
+    RemoteWithNewStructure(Node<'t>),
 
     /// An unchanged merge state means we don't need to do anything to the item.
     Unchanged { local_node: Node<'t>, remote_node: Node<'t> },
 }
 
 impl<'t> MergeState<'t> {
-    pub fn local(local_node: Node<'t>) -> MergeState {
-        MergeState::Local { local_node, remote_node: None }
-    }
-
-    pub fn remote(remote_node: Node<'t>) -> MergeState {
-        MergeState::Remote { local_node: None, remote_node }
-    }
-
     pub fn with_new_structure(&self) -> MergeState<'t> {
         match *self {
-            MergeState::Local { local_node, remote_node } => {
-                MergeState::LocalWithNewStructure { local_node, remote_node }
+            MergeState::Local(node) => {
+                MergeState::LocalWithNewStructure(node)
             },
-            MergeState::Remote { local_node, remote_node } => {
-                MergeState::RemoteWithNewStructure { local_node, remote_node }
+            MergeState::Remote(node) => {
+                MergeState::RemoteWithNewStructure(node)
             },
-            MergeState::Unchanged { local_node, remote_node } => {
+            MergeState::Unchanged { local_node, .. } => {
                 // Once the structure changes, it doesn't matter which side we
                 // pick; we'll need to reupload the item to the server, anyway.
-                MergeState::LocalWithNewStructure { local_node, remote_node: Some(remote_node) }
+                MergeState::LocalWithNewStructure(local_node)
             },
             state => state,
         }
@@ -521,10 +513,10 @@ impl<'t> MergeState<'t> {
 impl<'t> fmt::Display for MergeState<'t> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(match self {
-            MergeState::Local { .. } => "(Local, Local)",
-            MergeState::Remote { .. } => "(Remote, Remote)",
-            MergeState::LocalWithNewStructure { .. } => "(Local, New)",
-            MergeState::RemoteWithNewStructure { .. } => "(Remote, New)",
+            MergeState::Local(_) => "(Local, Local)",
+            MergeState::Remote(_) => "(Remote, Remote)",
+            MergeState::LocalWithNewStructure(_) => "(Local, New)",
+            MergeState::RemoteWithNewStructure(_) => "(Remote, New)",
             MergeState::Unchanged { .. } => "(Unchanged, Unchanged)"
         })
     }


### PR DESCRIPTION
Unchanged items exist on both sides, and don't need to be updated or uploaded. They're not handled specially in the merger (except to set flags in the tests), but we can apply them more efficiently, since we won't need to update their value or structure.

This is also a much cleaner way to handle the "exists only on one side" case in `use_remote` and `needs_upload`.

@bbangert, CCing you because this might be a good PR for us to pair review on Live Share, too! 👀