### PR TITLE
Fix up diverging structure in bookmark trees

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,4 @@ exclude = [".travis", ".travis.yml"]
 log = "0.4"
 
 [dev-dependencies]
-base64 = "0.10"
 env_logger = "0.5.6"
-rand = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,6 @@ exclude = [".travis", ".travis.yml"]
 log = "0.4"
 
 [dev-dependencies]
+base64 = "0.10"
 env_logger = "0.5.6"
+rand = "0.6"

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,7 +46,6 @@ impl fmt::Display for Error {
 pub enum ErrorKind {
     MismatchedItemKind(Kind, Kind),
     DuplicateItem(Guid),
-    MissingItem(Guid),
     InvalidParent(Guid, Guid),
     MissingParent(Guid, Guid),
     Storage(&'static str, u32),
@@ -65,9 +64,6 @@ impl fmt::Display for ErrorKind {
             },
             ErrorKind::DuplicateItem(guid) => {
                 write!(f, "Item {} already exists in tree", guid)
-            },
-            ErrorKind::MissingItem(guid) => {
-                write!(f, "Item {} is an orphan", guid)
             },
             ErrorKind::InvalidParent(child_guid, parent_guid) => {
                 write!(f, "Can't insert item {} into non-folder {}",

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,6 +53,7 @@ pub enum ErrorKind {
     MergeConflict,
     UnmergedLocalItems,
     UnmergedRemoteItems,
+    GenerateGuid,
 }
 
 impl fmt::Display for ErrorKind {
@@ -87,6 +88,9 @@ impl fmt::Display for ErrorKind {
             },
             ErrorKind::UnmergedRemoteItems => {
                 write!(f, "Merged tree doesn't mention all items from remote tree")
+            },
+            ErrorKind::GenerateGuid => {
+                write!(f, "Failed to generate GUID")
             }
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,7 +52,7 @@ pub enum ErrorKind {
     MergeConflict,
     UnmergedLocalItems,
     UnmergedRemoteItems,
-    GenerateGuid,
+    GenerateGuid(Guid),
 }
 
 impl fmt::Display for ErrorKind {
@@ -85,8 +85,8 @@ impl fmt::Display for ErrorKind {
             ErrorKind::UnmergedRemoteItems => {
                 write!(f, "Merged tree doesn't mention all items from remote tree")
             },
-            ErrorKind::GenerateGuid => {
-                write!(f, "Failed to generate GUID")
+            ErrorKind::GenerateGuid(invalid_guid) => {
+                write!(f, "Failed to generate new GUID for {}", invalid_guid)
             }
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,6 +46,7 @@ impl fmt::Display for Error {
 pub enum ErrorKind {
     MismatchedItemKind(Kind, Kind),
     DuplicateItem(Guid),
+    MissingItem(Guid),
     InvalidParent(Guid, Guid),
     MissingParent(Guid, Guid),
     Storage(&'static str, u32),
@@ -63,6 +64,9 @@ impl fmt::Display for ErrorKind {
             },
             ErrorKind::DuplicateItem(guid) => {
                 write!(f, "Item {} already exists in tree", guid)
+            },
+            ErrorKind::MissingItem(guid) => {
+                write!(f, "Item {} is an orphan", guid)
             },
             ErrorKind::InvalidParent(child_guid, parent_guid) => {
                 write!(f, "Can't insert item {} into non-folder {}",

--- a/src/guid.rs
+++ b/src/guid.rs
@@ -54,18 +54,6 @@ const VALID_GUID_BYTES: [u8; 255] =
      0, 0, 0, 0, 0, 0, 0];
 
 impl Guid {
-    pub fn new(s: &str) -> Guid {
-        let repr = if Guid::is_valid(s.as_bytes()) {
-            assert!(s.is_char_boundary(12));
-            let mut bytes = [0u8; 12];
-            bytes.copy_from_slice(s.as_bytes());
-            Repr::Fast(bytes)
-        } else {
-            Repr::Slow(s.into())
-        };
-        Guid(repr)
-    }
-
     pub fn from_utf8(b: &[u8]) -> Option<Guid> {
         let repr = if Guid::is_valid(b) {
             let mut bytes = [0u8; 12];
@@ -139,7 +127,15 @@ impl Guid {
 impl<'a> From<&'a str> for Guid {
     #[inline]
     fn from(s: &'a str) -> Guid {
-        Guid::new(s)
+        let repr = if Guid::is_valid(s.as_bytes()) {
+            assert!(s.is_char_boundary(12));
+            let mut bytes = [0u8; 12];
+            bytes.copy_from_slice(s.as_bytes());
+            Repr::Fast(bytes)
+        } else {
+            Repr::Slow(s.into())
+        };
+        Guid(repr)
     }
 }
 

--- a/src/guid.rs
+++ b/src/guid.rs
@@ -120,6 +120,13 @@ impl Guid {
         }
     }
 
+    pub fn valid(&self) -> bool {
+        match self.0 {
+            Repr::Fast(_) => true,
+            Repr::Slow(_) => false,
+        }
+    }
+
     /// Equivalent to `PlacesUtils.isValidGuid`.
     #[inline]
     fn is_valid<T: Copy + IntoByte>(bytes: &[T]) -> bool {

--- a/src/guid.rs
+++ b/src/guid.rs
@@ -30,12 +30,15 @@ enum Repr {
 /// The Places root GUID, used to root all items in a bookmark tree.
 pub const ROOT_GUID: Guid = Guid(Repr::Fast(*b"root________"));
 
+/// The "Other Bookmarks" GUID, used to hold items without a parent.
+pub const UNFILED_GUID: Guid = Guid(Repr::Fast(*b"unfiled_____"));
+
 /// The syncable Places roots. All synced items should descend from these
 /// roots.
 pub const USER_CONTENT_ROOTS: [Guid; 4] = [
     Guid(Repr::Fast(*b"toolbar_____")),
     Guid(Repr::Fast(*b"menu________")),
-    Guid(Repr::Fast(*b"unfiled_____")),
+    UNFILED_GUID,
     Guid(Repr::Fast(*b"mobile______")),
 ];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,5 +27,5 @@ mod tests;
 pub use error::{Error, ErrorKind, Result};
 pub use guid::{Guid, ROOT_GUID, USER_CONTENT_ROOTS};
 pub use merge::{Deletion, Merger, StructureCounts};
-pub use store::{Store, merge};
-pub use tree::{Content, Item, Kind, MergeState, MergedNode, Tree};
+pub use store::Store;
+pub use tree::{Child, Content, Item, Kind, MergeState, MergedNode, ParentGuidFrom, Tree};

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -203,7 +203,7 @@ impl<'t> Merger<'t> {
             } else {
                 let local_level = self.local_tree
                                       .node_for_guid(guid)
-                                      .and_then(|node| node.level())
+                                      .map(|node| node.level())
                                       .unwrap_or(-1);
                 // Items that should be deleted locally already have tombstones
                 // on the server, so we don't need to upload tombstones for
@@ -219,7 +219,7 @@ impl<'t> Merger<'t> {
         self.delete_remotely.iter().map(move |guid| {
             let local_level = self.local_tree
                                   .node_for_guid(guid)
-                                  .and_then(|node| node.level())
+                                  .map(|node| node.level())
                                   .unwrap_or(-1);
             Deletion { guid: guid.to_owned(),
                        local_level,

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -90,7 +90,7 @@ impl Driver for DefaultDriver {
     /// The default implementation returns an error and fails the merge if any
     /// items have invalid GUIDs.
     fn generate_new_guid(&self, invalid_guid: &Guid) -> Result<Guid> {
-        Err(ErrorKind::GenerateGuid(invalid_guid.clone()).into())
+        Err(ErrorKind::InvalidGuid(invalid_guid.clone()).into())
     }
 }
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -16,8 +16,8 @@ use std::{collections::{HashMap, HashSet, VecDeque},
           mem};
 
 use error::{ErrorKind, Result};
-use guid::{Guid, ROOT_GUID, USER_CONTENT_ROOTS};
-use tree::{Content, Item, MergeState, MergedNode, Node, Tree};
+use guid::Guid;
+use tree::{Content, MergeState, MergedNode, Node, Tree};
 
 /// Structure change types, used to indicate if a node on one side is moved
 /// or deleted on the other.
@@ -237,13 +237,13 @@ impl<'t> Merger<'t> {
     fn merge_local_node(&mut self, local_node: Node<'t>) -> Result<MergedNode<'t>> {
         trace!("Item {} only exists locally", local_node);
 
-        self.merged_guids.insert(local_node.guid().clone());
+        self.merged_guids.insert(local_node.guid.clone());
 
-        let merged_guid = if local_node.guid().valid() {
-            local_node.guid().clone()
+        let merged_guid = if local_node.guid.valid() {
+            local_node.guid.clone()
         } else {
-            let new_guid = self.driver.generate_new_guid(local_node.guid())?;
-            if &new_guid != local_node.guid() {
+            let new_guid = self.driver.generate_new_guid(&local_node.guid)?;
+            if new_guid != local_node.guid {
                 self.merged_guids.insert(new_guid.clone());
             }
             new_guid
@@ -270,16 +270,16 @@ impl<'t> Merger<'t> {
     fn merge_remote_node(&mut self, remote_node: Node<'t>) -> Result<MergedNode<'t>> {
         trace!("Item {} only exists remotely", remote_node);
 
-        self.merged_guids.insert(remote_node.guid().clone());
+        self.merged_guids.insert(remote_node.guid.clone());
 
-        let merged_guid = if remote_node.guid().valid() {
-            remote_node.guid().clone()
+        let merged_guid = if remote_node.guid.valid() {
+            remote_node.guid.clone()
         } else {
-            let new_guid = self.driver.generate_new_guid(remote_node.guid())?;
-            if &new_guid != remote_node.guid() {
+            let new_guid = self.driver.generate_new_guid(&remote_node.guid)?;
+            if new_guid != remote_node.guid {
                 self.merged_guids.insert(new_guid.clone());
                 // Upload tombstones for changed remote GUIDs.
-                self.delete_remotely.insert(remote_node.guid().clone());
+                self.delete_remotely.insert(remote_node.guid.clone());
             }
             new_guid
         };
@@ -307,78 +307,72 @@ impl<'t> Merger<'t> {
                      remote_node: Node<'t>)
                      -> Result<MergedNode<'t>>
     {
-        match (&*local_node, &*remote_node) {
-            (Item::Missing(guid), _) => Err(ErrorKind::MissingItem(guid.clone()).into()),
-            (_, Item::Missing(guid)) => Err(ErrorKind::MissingItem(guid.clone()).into()),
-            (Item::Existing { kind: local_kind, .. }, Item::Existing { kind: remote_kind, .. }) => {
-                trace!("Item exists locally as {} and remotely as {}",
-                    local_node,
-                    remote_node);
+        trace!("Item exists locally as {} and remotely as {}",
+               local_node,
+               remote_node);
 
-                if !local_node.has_compatible_kind(&remote_node) {
-                    // TODO(lina): Fix up kind mismatches in
-                    // `check_for_{}_structure_change_of_{}_node`.
-                    error!("Merging local {} and remote {} with different kinds",
-                        local_node, remote_node);
-                    return Err(ErrorKind::MismatchedItemKind(*local_kind, *remote_kind).into());
-                }
-
-                self.merged_guids.insert(remote_node.guid().clone());
-
-                if local_node.guid() != remote_node.guid() {
-                    // We deduped a NEW local item to a remote item.
-                    self.merged_guids.insert(local_node.guid().clone());
-                }
-
-                let (item, children) = self.resolve_value_conflict(local_node, remote_node);
-
-                let mut merged_node = MergedNode::new(remote_node.guid().clone(), match item {
-                    ConflictResolution::Local => {
-                        MergeState::Local(local_node)
-                    },
-                    ConflictResolution::Remote => {
-                        MergeState::Remote(remote_node)
-                    },
-                    ConflictResolution::Unchanged => {
-                        MergeState::Unchanged { local_node, remote_node }
-                    },
-                });
-
-                match children {
-                    ConflictResolution::Local => {
-                        for local_child_node in local_node.children() {
-                            self.merge_local_child_into_merged_node(&mut merged_node,
-                                                                    local_node,
-                                                                    Some(remote_node),
-                                                                    local_child_node)?;
-                        }
-                        for remote_child_node in remote_node.children() {
-                            self.merge_remote_child_into_merged_node(&mut merged_node,
-                                                                     Some(local_node),
-                                                                     remote_node,
-                                                                     remote_child_node)?;
-                        }
-                    },
-
-                    ConflictResolution::Remote | ConflictResolution::Unchanged => {
-                        for remote_child_node in remote_node.children() {
-                            self.merge_remote_child_into_merged_node(&mut merged_node,
-                                                                     Some(local_node),
-                                                                     remote_node,
-                                                                     remote_child_node)?;
-                        }
-                        for local_child_node in local_node.children() {
-                            self.merge_local_child_into_merged_node(&mut merged_node,
-                                                                    local_node,
-                                                                    Some(remote_node),
-                                                                    local_child_node)?;
-                        }
-                    },
-                }
-
-                Ok(merged_node)
-            }
+        if !local_node.has_compatible_kind(&remote_node) {
+            // TODO(lina): Remove and replace items with mismatched kinds in
+            // `check_for_{}_structure_change_of_{}_node`.
+            error!("Merging local {} and remote {} with different kinds",
+                   local_node, remote_node);
+            return Err(ErrorKind::MismatchedItemKind(local_node.kind, remote_node.kind).into());
         }
+
+        self.merged_guids.insert(remote_node.guid.clone());
+
+        if local_node.guid != remote_node.guid {
+            // We deduped a NEW local item to a remote item.
+            self.merged_guids.insert(local_node.guid.clone());
+        }
+
+        let (item, children) = self.resolve_value_conflict(local_node, remote_node);
+
+        let mut merged_node = MergedNode::new(remote_node.guid.clone(), match item {
+            ConflictResolution::Local => {
+                MergeState::Local(local_node)
+            },
+            ConflictResolution::Remote => {
+                MergeState::Remote(remote_node)
+            },
+            ConflictResolution::Unchanged => {
+                MergeState::Unchanged { local_node, remote_node }
+            },
+        });
+
+        match children {
+            ConflictResolution::Local => {
+                for local_child_node in local_node.children() {
+                    self.merge_local_child_into_merged_node(&mut merged_node,
+                                                            local_node,
+                                                            Some(remote_node),
+                                                            local_child_node)?;
+                }
+                for remote_child_node in remote_node.children() {
+                    self.merge_remote_child_into_merged_node(&mut merged_node,
+                                                             Some(local_node),
+                                                             remote_node,
+                                                             remote_child_node)?;
+                }
+            },
+
+            ConflictResolution::Remote | ConflictResolution::Unchanged => {
+                for remote_child_node in remote_node.children() {
+                    self.merge_remote_child_into_merged_node(&mut merged_node,
+                                                             Some(local_node),
+                                                             remote_node,
+                                                             remote_child_node)?;
+                }
+                for local_child_node in local_node.children() {
+                    self.merge_local_child_into_merged_node(&mut merged_node,
+                                                            local_node,
+                                                            Some(remote_node),
+                                                            local_child_node)?;
+                }
+            },
+        }
+
+        Ok(merged_node)
     }
 
     /// Merges a remote child node into a merged folder node. This handles the
@@ -405,7 +399,7 @@ impl<'t> Merger<'t> {
                                            remote_child_node: Node<'t>)
                                            -> Result<()>
     {
-        if self.merged_guids.contains(&remote_child_node.guid()) {
+        if self.merged_guids.contains(&remote_child_node.guid) {
             trace!("Remote child {} already seen in another folder and merged",
                    remote_child_node);
             return Ok(());
@@ -434,7 +428,7 @@ impl<'t> Merger<'t> {
         }
 
         // The remote child isn't locally deleted. Does it exist in the local tree?
-        if let Some(local_child_node) = self.local_tree.node_for_guid(&remote_child_node.guid()) {
+        if let Some(local_child_node) = self.local_tree.node_for_guid(&remote_child_node.guid) {
             // The remote child exists in the local tree. Did it move?
             let local_parent_node =
                 local_child_node.parent()
@@ -445,31 +439,16 @@ impl<'t> Merger<'t> {
                    local_parent_node,
                    remote_parent_node);
 
-            if self.remote_tree.is_deleted(&local_parent_node.guid()) {
+            if self.remote_tree.is_deleted(&local_parent_node.guid) {
                 trace!("Unconditionally taking remote move for {} to {} because local parent {} is \
                         deleted remotely",
                        remote_child_node,
                        remote_parent_node,
                        local_parent_node);
 
-                let mut merged_child_node = match (&*local_child_node, &*remote_child_node) {
-                    (Item::Missing(_), Item::Existing { .. }) => {
-                        self.merge_remote_node(remote_child_node)?
-                    },
-                    (Item::Existing { .. }, Item::Missing(_)) => {
-                        let merged_child_node = self.merge_local_node(local_child_node)?;
-                        merged_node.merge_state = merged_node.merge_state.with_new_structure();
-                        merged_child_node
-                    },
-                    (Item::Existing { .. }, Item::Existing { .. }) => {
-                        self.two_way_merge(local_child_node, remote_child_node)?
-                    },
-                    (Item::Missing(_), Item::Missing(_)) => {
-                        merged_node.merge_state = merged_node.merge_state.with_new_structure();
-                        return Ok(());
-                    },
-                };
-                if remote_child_node.diverged() || &merged_node.guid != remote_parent_node.guid() {
+                let mut merged_child_node = self.two_way_merge(local_child_node,
+                                                               remote_child_node)?;
+                if remote_child_node.diverged() || merged_node.guid != remote_parent_node.guid {
                     // If the remote structure diverged, or the merged parent
                     // GUID changed, flag the remote child for reupload so that
                     // its `parentid` is correct.
@@ -511,26 +490,9 @@ impl<'t> Merger<'t> {
                            local_parent_node,
                            remote_parent_node);
 
-                    let mut merged_child_node = match (&*local_child_node, &*remote_child_node) {
-                        (Item::Missing(_), Item::Existing { .. }) => {
-                            self.merge_remote_node(remote_child_node)?
-                        },
-                        (Item::Existing { .. }, Item::Missing(_)) => {
-                            let merged_child_node = self.merge_local_node(local_child_node)?;
-                            merged_node.merge_state = merged_node.merge_state.with_new_structure();
-                            merged_child_node
-                        },
-                        (Item::Existing { .. }, Item::Existing { .. }) => {
-                            self.two_way_merge(local_child_node, remote_child_node)?
-                        },
-                        (Item::Missing(_), Item::Missing(_)) => {
-                            merged_node.merge_state = merged_node.merge_state.with_new_structure();
-                            return Ok(());
-                        },
-                    };
-                    if remote_child_node.diverged() ||
-                        &merged_node.guid != remote_parent_node.guid() {
-
+                    let mut merged_child_node = self.two_way_merge(local_child_node,
+                                                                   remote_child_node)?;
+                    if remote_child_node.diverged() || merged_node.guid != remote_parent_node.guid {
                         merged_child_node.merge_state =
                             merged_child_node.merge_state.with_new_structure();
                     }
@@ -547,25 +509,17 @@ impl<'t> Merger<'t> {
         trace!("Remote child {} doesn't exist locally; looking for local content match",
                remote_child_node);
 
-        let mut merged_child_node = match &*remote_child_node {
-            Item::Missing(_) => {
-                merged_node.merge_state = merged_node.merge_state.with_new_structure();
-                return Ok(());
-            },
-            Item::Existing { .. } => {
-                if let Some(local_child_node_by_content) =
-                    self.find_local_node_matching_remote_node(merged_node,
-                                                              local_parent_node,
-                                                              remote_parent_node,
-                                                              remote_child_node)
-                {
-                    self.two_way_merge(local_child_node_by_content, remote_child_node)
-                } else {
-                    self.merge_remote_node(remote_child_node)
-                }?
-            },
-        };
-        if remote_child_node.diverged() || &merged_node.guid != remote_parent_node.guid() {
+        let mut merged_child_node = if let Some(local_child_node_by_content) =
+            self.find_local_node_matching_remote_node(merged_node,
+                                                      local_parent_node,
+                                                      remote_parent_node,
+                                                      remote_child_node)
+        {
+            self.two_way_merge(local_child_node_by_content, remote_child_node)
+        } else {
+            self.merge_remote_node(remote_child_node)
+        }?;
+        if remote_child_node.diverged() || merged_node.guid != remote_parent_node.guid {
             merged_child_node.merge_state = merged_child_node.merge_state.with_new_structure();
         }
         merged_node.merged_children.push(merged_child_node);
@@ -585,7 +539,7 @@ impl<'t> Merger<'t> {
                                           local_child_node: Node<'t>)
                                           -> Result<()>
     {
-        if self.merged_guids.contains(&local_child_node.guid()) {
+        if self.merged_guids.contains(&local_child_node.guid) {
             // We already merged the child when we walked another folder.
             trace!("Local child {} already seen in another folder and merged",
                    local_child_node);
@@ -611,7 +565,7 @@ impl<'t> Merger<'t> {
 
         // At this point, we know the local child isn't deleted. See if it
         // exists in the remote tree.
-        if let Some(remote_child_node) = self.remote_tree.node_for_guid(&local_child_node.guid()) {
+        if let Some(remote_child_node) = self.remote_tree.node_for_guid(&local_child_node.guid) {
             // The local child exists remotely. It must have moved; otherwise, we
             // would have seen it when we walked the remote children.
             let remote_parent_node =
@@ -623,7 +577,7 @@ impl<'t> Merger<'t> {
                    local_parent_node,
                    remote_parent_node);
 
-            if self.local_tree.is_deleted(&remote_parent_node.guid()) {
+            if self.local_tree.is_deleted(&remote_parent_node.guid) {
                 trace!("Unconditionally taking local move for {} to {} because remote parent {} is \
                         deleted locally",
                        local_child_node,
@@ -639,21 +593,8 @@ impl<'t> Merger<'t> {
                 //
                 // However, older Desktop and Android use the child's `parentid` as
                 // canonical, while iOS is stricter and requires both to match.
-                let mut merged_child_node = match (&*local_child_node, &*remote_child_node) {
-                    (Item::Missing(_), Item::Existing { .. }) => {
-                        self.merge_remote_node(remote_child_node)
-                    },
-                    (Item::Existing { .. }, Item::Missing(_)) => {
-                        self.merge_local_node(local_child_node)
-                    },
-                    (Item::Existing { .. }, Item::Existing { .. }) => {
-                        self.two_way_merge(local_child_node, remote_child_node)
-                    },
-                    (Item::Missing(_), Item::Missing(_)) => {
-                        merged_node.merge_state = merged_node.merge_state.with_new_structure();
-                        return Ok(());
-                    },
-                }?;
+                let mut merged_child_node = self.two_way_merge(local_child_node,
+                                                               remote_child_node)?;
                 merged_node.merge_state = merged_node.merge_state.with_new_structure();
                 merged_child_node.merge_state = merged_child_node.merge_state.with_new_structure();
                 merged_node.merged_children.push(merged_child_node);
@@ -668,7 +609,7 @@ impl<'t> Merger<'t> {
                 ConflictResolution::Local => {
                     // The local move is newer, so we merge the local child now
                     // and ignore the remote move.
-                    if local_parent_node.guid() != remote_parent_node.guid() {
+                    if local_parent_node.guid != remote_parent_node.guid {
                         // The child moved to a different folder.
                         trace!("Local child {} reparented locally to {} and remotely to {}; \
                                 keeping child in newer local parent",
@@ -678,22 +619,8 @@ impl<'t> Merger<'t> {
 
                         // Merge and flag both the new parent and child for
                         // reupload. See above for why.
-                        let mut merged_child_node = match (&*local_child_node, &*remote_child_node) {
-                            (Item::Missing(_), Item::Existing { .. }) => {
-                                self.merge_remote_node(remote_child_node)
-                            },
-                            (Item::Existing { .. }, Item::Missing(_)) => {
-                                self.merge_local_node(local_child_node)
-                            },
-                            (Item::Existing { .. }, Item::Existing { .. }) => {
-                                self.two_way_merge(local_child_node, remote_child_node)
-                            },
-                            (Item::Missing(_), Item::Missing(_)) => {
-                                merged_node.merge_state =
-                                    merged_node.merge_state.with_new_structure();
-                                return Ok(());
-                            },
-                        }?;
+                        let mut merged_child_node = self.two_way_merge(local_child_node,
+                                                                       remote_child_node)?;
                         merged_node.merge_state = merged_node.merge_state.with_new_structure();
                         merged_child_node.merge_state =
                             merged_child_node.merge_state.with_new_structure();
@@ -706,30 +633,12 @@ impl<'t> Merger<'t> {
                                remote_parent_node);
 
                         // For position changes in the same folder, we only need to
-                        // merge and flag the parent for reupload. If the
-                        // repositioned item is an orphan, we need to flag it,
-                        // too.
-                        let mut merged_child_node = match (&*local_child_node, &*remote_child_node) {
-                            (Item::Missing(_), Item::Existing { .. }) => {
-                                self.merge_remote_node(remote_child_node)?
-                            },
-                            (Item::Existing { .. }, Item::Missing(_)) => {
-                                let mut merged_child_node = self.merge_local_node(local_child_node)?;
-                                merged_child_node.merge_state =
-                                    merged_child_node.merge_state.with_new_structure();
-                                merged_child_node
-                            },
-                            (Item::Existing { .. }, Item::Existing { .. }) => {
-                                self.two_way_merge(local_child_node, remote_child_node)?
-                            },
-                            (Item::Missing(_), Item::Missing(_)) => {
-                                merged_node.merge_state = merged_node.merge_state.with_new_structure();
-                                return Ok(());
-                            },
-                        };
+                        // merge and flag the parent for reupload.
+                        let mut merged_child_node = self.two_way_merge(local_child_node,
+                                                                       remote_child_node)?;
                         merged_node.merge_state = merged_node.merge_state.with_new_structure();
                         if remote_child_node.diverged() ||
-                            &merged_node.guid != remote_parent_node.guid() {
+                            merged_node.guid != remote_parent_node.guid {
 
                             // ...But repositioning an item in a diverged folder, or in a folder
                             // with an invalid GUID, should reupload the item.
@@ -744,7 +653,7 @@ impl<'t> Merger<'t> {
                     // The remote move is newer, so we ignore the local
                     // move. We'll merge the local child later, when we
                     // walk its new remote parent.
-                    if local_parent_node.guid() != remote_parent_node.guid() {
+                    if local_parent_node.guid != remote_parent_node.guid {
                         trace!("Local child {} reparented locally to {} and remotely to {}; \
                                 keeping child in newer remote parent",
                                local_child_node,
@@ -769,35 +678,31 @@ impl<'t> Merger<'t> {
         trace!("Local child {} doesn't exist remotely; looking for remote content match",
                local_child_node);
 
-        let merged_child_node = match &*local_child_node {
-            Item::Missing(_) => return Ok(()),
-            Item::Existing { .. } => {
-                if let Some(remote_child_node_by_content) =
-                    self.find_remote_node_matching_local_node(merged_node,
-                                                              local_parent_node,
-                                                              remote_parent_node,
-                                                              local_child_node)
-                {
-                    // The local child has a remote content match, so take the remote GUID
-                    // and merge.
-                    let mut merged_child_node = self.two_way_merge(local_child_node, remote_child_node_by_content)?;
-                    if remote_child_node_by_content.diverged() ||
-                        remote_parent_node.map(|node| &merged_node.guid != node.guid()).unwrap_or(false) {
+        let merged_child_node = if let Some(remote_child_node_by_content) =
+            self.find_remote_node_matching_local_node(merged_node,
+                                                      local_parent_node,
+                                                      remote_parent_node,
+                                                      local_child_node)
+        {
+            // The local child has a remote content match, so take the remote GUID
+            // and merge.
+            let mut merged_child_node = self.two_way_merge(local_child_node,
+                                                           remote_child_node_by_content)?;
+            if remote_child_node_by_content.diverged() ||
+                remote_parent_node.map(|node| merged_node.guid != node.guid).unwrap_or(false) {
 
-                        merged_node.merge_state = merged_node.merge_state.with_new_structure();
-                        merged_child_node.merge_state =
-                            merged_child_node.merge_state.with_new_structure();
-                    }
-                    merged_child_node
-                } else {
-                    // The local child doesn't exist remotely, so flag the merged parent and
-                    // new child for upload, and walk its descendants.
-                    let mut merged_child_node = self.merge_local_node(local_child_node)?;
-                    merged_node.merge_state = merged_node.merge_state.with_new_structure();
-                    merged_child_node.merge_state = merged_child_node.merge_state.with_new_structure();
-                    merged_child_node
-                }
-            },
+                merged_node.merge_state = merged_node.merge_state.with_new_structure();
+                merged_child_node.merge_state =
+                    merged_child_node.merge_state.with_new_structure();
+            }
+            merged_child_node
+        } else {
+            // The local child doesn't exist remotely, so flag the merged parent and
+            // new child for upload, and walk its descendants.
+            let mut merged_child_node = self.merge_local_node(local_child_node)?;
+            merged_node.merge_state = merged_node.merge_state.with_new_structure();
+            merged_child_node.merge_state = merged_child_node.merge_state.with_new_structure();
+            merged_child_node
         };
         merged_node.merged_children.push(merged_child_node);
         Ok(())
@@ -810,38 +715,30 @@ impl<'t> Merger<'t> {
                               remote_node: Node<'t>)
                               -> (ConflictResolution, ConflictResolution)
     {
-        if remote_node.guid() == &ROOT_GUID {
+        if remote_node.is_root() {
             // Don't reorder local roots.
             return (ConflictResolution::Local, ConflictResolution::Local);
         }
 
-        match (local_node.needs_merge(), remote_node.needs_merge()) {
+        match (local_node.needs_merge, remote_node.needs_merge) {
             (true, true) => match (local_node.diverged(), remote_node.diverged()) {
                 (true, false) => (ConflictResolution::Remote, ConflictResolution::Remote),
                 (false, true) => (ConflictResolution::Local, ConflictResolution::Local),
                 _ => {
                     // The item changed locally and remotely.
-                    if local_node.age() < remote_node.age() {
+                    if local_node.age < remote_node.age {
                         // The local change is newer, so merge local children first,
                         // followed by remaining unmerged remote children.
                         (ConflictResolution::Local, ConflictResolution::Local)
                     } else {
                         // The remote change is newer, so walk and merge remote
                         // children first, then remaining local children.
-                        if USER_CONTENT_ROOTS.contains(&remote_node.guid()) {
+                        if remote_node.is_user_content_root() {
                             // Don't update root titles or other properties, but
                             // use their newer remote structure.
                             (ConflictResolution::Local, ConflictResolution::Remote)
                         } else {
-                            // The remote change is newer, so walk and merge remote
-                            // children first, then remaining local children.
-                            if USER_CONTENT_ROOTS.contains(&remote_node.guid()) {
-                                // Don't update root titles or other properties, but
-                                // use their newer remote structure.
-                                (ConflictResolution::Local, ConflictResolution::Remote)
-                            } else {
-                                (ConflictResolution::Remote, ConflictResolution::Remote)
-                            }
+                            (ConflictResolution::Remote, ConflictResolution::Remote)
                         }
                     }
                 },
@@ -858,7 +755,7 @@ impl<'t> Merger<'t> {
                 // The item changed remotely, but not locally. Take the
                 // remote state, then merge remote children first, followed
                 // by local children.
-                if USER_CONTENT_ROOTS.contains(&remote_node.guid()) {
+                if remote_node.is_user_content_root() {
                     (ConflictResolution::Local, ConflictResolution::Remote)
                 } else {
                     (ConflictResolution::Remote, ConflictResolution::Remote)
@@ -880,20 +777,20 @@ impl<'t> Merger<'t> {
                                   remote_child_node: Node<'t>)
                                   -> ConflictResolution
     {
-        if USER_CONTENT_ROOTS.contains(&remote_child_node.guid()) {
+        if remote_child_node.is_user_content_root() {
             // Always use the local parent and position for roots.
             return ConflictResolution::Local;
         }
 
-        match (local_parent_node.needs_merge(), remote_parent_node.needs_merge()) {
+        match (local_parent_node.needs_merge, remote_parent_node.needs_merge) {
             (true, true) => match (local_parent_node.diverged(), remote_parent_node.diverged()) {
                 (true, false) => ConflictResolution::Remote,
                 (false, true) => ConflictResolution::Local,
                 _ => {
                     // If both parents changed, compare timestamps to decide where
                     // to keep the local child.
-                    let latest_local_age = local_child_node.age().min(local_parent_node.age());
-                    let latest_remote_age = remote_child_node.age().min(remote_parent_node.age());
+                    let latest_local_age = local_child_node.age.min(local_parent_node.age);
+                    let latest_remote_age = remote_child_node.age.min(remote_parent_node.age);
 
                     if latest_local_age < latest_remote_age {
                         ConflictResolution::Local
@@ -903,19 +800,10 @@ impl<'t> Merger<'t> {
                 },
             },
 
-            (true, false) => {
-                // If only the local parent changed, keep the local child in its
-                // new parent.
-                ConflictResolution::Local
-            },
-
-            (false, true) => {
-                if USER_CONTENT_ROOTS.contains(&remote_child_node.guid()) {
-                    ConflictResolution::Local
-                } else {
-                    ConflictResolution::Remote
-                }
-            },
+            // If only the local or remote parent changed, keep the child in its
+            // new parent.
+            (true, false) => ConflictResolution::Local,
+            (false, true) => ConflictResolution::Remote,
 
             (false, false) => ConflictResolution::Unchanged
         }
@@ -935,7 +823,7 @@ impl<'t> Merger<'t> {
         if !remote_node.is_syncable() {
             // If the remote node is known to be non-syncable, we unconditionally
             // delete it from the server, even if it's syncable locally.
-            self.delete_remotely.insert(remote_node.guid().clone());
+            self.delete_remotely.insert(remote_node.guid.clone());
             if remote_node.is_folder() {
                 // If the remote node is a folder, we also need to walk its descendants
                 // and reparent any syncable descendants, and descendants that only
@@ -945,13 +833,13 @@ impl<'t> Merger<'t> {
             return Ok(StructureChange::Deleted);
         }
 
-        if !self.local_tree.is_deleted(&remote_node.guid()) {
-            if let Some(local_node) = self.local_tree.node_for_guid(&remote_node.guid()) {
+        if !self.local_tree.is_deleted(&remote_node.guid) {
+            if let Some(local_node) = self.local_tree.node_for_guid(&remote_node.guid) {
                 if !local_node.is_syncable() {
                     // The remote node is syncable, but the local node is non-syncable.
                     // For consistency with Desktop, we unconditionally delete the
                     // node from the server.
-                    self.delete_remotely.insert(remote_node.guid().clone());
+                    self.delete_remotely.insert(remote_node.guid.clone());
                     if remote_node.is_folder() {
                         self.relocate_remote_orphans_to_merged_node(merged_node, remote_node)?;
                     }
@@ -960,7 +848,7 @@ impl<'t> Merger<'t> {
                 let local_parent_node =
                     local_node.parent()
                               .expect("Can't check for structure changes without local parent");
-                if local_parent_node.guid() != remote_parent_node.guid() {
+                if local_parent_node.guid != remote_parent_node.guid {
                     return Ok(StructureChange::Moved);
                 }
                 return Ok(StructureChange::Unchanged);
@@ -969,7 +857,7 @@ impl<'t> Merger<'t> {
             }
         }
 
-        if remote_node.needs_merge() {
+        if remote_node.needs_merge {
             if !remote_node.is_folder() {
                 // If a non-folder child is deleted locally and changed remotely, we
                 // ignore the local deletion and take the remote child.
@@ -994,7 +882,7 @@ impl<'t> Merger<'t> {
 
         // Take the local deletion and relocate any new remote descendants to the
         // merged node.
-        self.delete_remotely.insert(remote_node.guid().clone());
+        self.delete_remotely.insert(remote_node.guid.clone());
         if remote_node.is_folder() {
             self.relocate_remote_orphans_to_merged_node(merged_node, remote_node)?;
         }
@@ -1015,21 +903,21 @@ impl<'t> Merger<'t> {
         if !local_node.is_syncable() {
             // If the local node is known to be non-syncable, we unconditionally
             // delete it from the local tree, even if it's syncable remotely.
-            self.delete_locally.insert(local_node.guid().clone());
+            self.delete_locally.insert(local_node.guid.clone());
             if local_node.is_folder() {
                 self.relocate_local_orphans_to_merged_node(merged_node, local_node)?;
             }
             return Ok(StructureChange::Deleted);
         }
 
-        if !self.remote_tree.is_deleted(&local_node.guid()) {
-            if let Some(remote_node) = self.remote_tree.node_for_guid(&local_node.guid()) {
+        if !self.remote_tree.is_deleted(&local_node.guid) {
+            if let Some(remote_node) = self.remote_tree.node_for_guid(&local_node.guid) {
                 if !remote_node.is_syncable() {
                     // The local node is syncable, but the remote node is non-syncable.
                     // This can happen if we applied an orphaned left pane query in a
                     // previous sync, and later saw the left pane root on the server.
                     // Since we now have the complete subtree, we can remove the item.
-                    self.delete_locally.insert(local_node.guid().clone());
+                    self.delete_locally.insert(local_node.guid.clone());
                     if remote_node.is_folder() {
                         self.relocate_local_orphans_to_merged_node(merged_node, local_node)?;
                     }
@@ -1038,7 +926,7 @@ impl<'t> Merger<'t> {
                 let remote_parent_node =
                     remote_node.parent()
                                .expect("Can't check for structure changes without remote parent");
-                if remote_parent_node.guid() != local_parent_node.guid() {
+                if remote_parent_node.guid != local_parent_node.guid {
                     return Ok(StructureChange::Moved);
                 }
                 return Ok(StructureChange::Unchanged);
@@ -1047,7 +935,7 @@ impl<'t> Merger<'t> {
             }
         }
 
-        if local_node.needs_merge() {
+        if local_node.needs_merge {
             if !local_node.is_folder() {
                 trace!("Local non-folder {} deleted remotely and changed locally; taking local \
                         change",
@@ -1066,7 +954,7 @@ impl<'t> Merger<'t> {
 
         // Take the remote deletion and relocate any new local descendants to the
         // merged node.
-        self.delete_locally.insert(local_node.guid().clone());
+        self.delete_locally.insert(local_node.guid.clone());
         if local_node.is_folder() {
             self.relocate_local_orphans_to_merged_node(merged_node, local_node)?;
         }
@@ -1086,7 +974,7 @@ impl<'t> Merger<'t> {
                                               -> Result<()>
     {
         for remote_child_node in remote_node.children() {
-            if self.merged_guids.contains(&remote_child_node.guid()) {
+            if self.merged_guids.contains(&remote_child_node.guid) {
                 trace!("Remote child {} can't be an orphan; already merged", remote_child_node);
                 continue;
             }
@@ -1105,33 +993,12 @@ impl<'t> Merger<'t> {
                            merged_node);
 
                     // Flag the new parent and moved remote orphan for reupload.
-                    let mut merged_orphan_node = match
-                        self.local_tree.node_for_guid(&remote_child_node.guid())
+                    let mut merged_orphan_node = if let Some(local_child_node) =
+                        self.local_tree.node_for_guid(&remote_child_node.guid)
                     {
-                        Some(local_child_node) => match (&*local_child_node, &*remote_child_node) {
-                            (Item::Missing(_), Item::Missing(_)) => {
-                                merged_node.merge_state =
-                                    merged_node.merge_state.with_new_structure();
-                                continue;
-                            },
-                            (Item::Existing { .. }, Item::Missing(_)) => {
-                                self.merge_local_node(local_child_node)
-                            },
-                            (Item::Missing(_), Item::Existing { .. }) => {
-                                self.merge_remote_node(remote_child_node)
-                            },
-                            (Item::Existing {.. }, Item::Existing { .. }) => {
-                                self.two_way_merge(local_child_node, remote_child_node)
-                            },
-                        },
-                        None => match &*remote_child_node {
-                            Item::Missing(_) => {
-                                merged_node.merge_state =
-                                    merged_node.merge_state.with_new_structure();
-                                continue;
-                            },
-                            Item::Existing { .. } => self.merge_remote_node(remote_child_node),
-                        },
+                        self.two_way_merge(local_child_node, remote_child_node)
+                    } else {
+                        self.merge_remote_node(remote_child_node)
                     }?;
                     merged_node.merge_state = merged_node.merge_state.with_new_structure();
                     merged_orphan_node.merge_state =
@@ -1154,7 +1021,7 @@ impl<'t> Merger<'t> {
                                              -> Result<()>
     {
         for local_child_node in local_node.children() {
-            if self.merged_guids.contains(&local_child_node.guid()) {
+            if self.merged_guids.contains(&local_child_node.guid) {
                 trace!("Local child {} can't be an orphan; already merged", local_child_node);
                 continue;
             }
@@ -1173,33 +1040,12 @@ impl<'t> Merger<'t> {
                            merged_node);
 
                     // Flag the new parent and moved local orphan for reupload.
-                    let mut merged_orphan_node = match
-                        self.remote_tree.node_for_guid(&local_child_node.guid())
+                    let mut merged_orphan_node = if let Some(remote_child_node) =
+                        self.remote_tree.node_for_guid(&local_child_node.guid)
                     {
-                        Some(remote_child_node) => match (&*local_child_node, &*remote_child_node) {
-                            (Item::Missing(_), Item::Missing(_)) => {
-                                merged_node.merge_state =
-                                    merged_node.merge_state.with_new_structure();
-                                continue;
-                            },
-                            (Item::Existing { .. }, Item::Missing(_)) => {
-                                self.merge_local_node(local_child_node)
-                            },
-                            (Item::Missing(_), Item::Existing { .. }) => {
-                                self.merge_remote_node(remote_child_node)
-                            },
-                            (Item::Existing {.. }, Item::Existing { .. }) => {
-                                self.two_way_merge(local_child_node, remote_child_node)
-                            },
-                        },
-                        None => match &*local_child_node {
-                            Item::Missing(_) => {
-                                merged_node.merge_state =
-                                    merged_node.merge_state.with_new_structure();
-                                continue;
-                            },
-                            Item::Existing { .. } => self.merge_local_node(local_child_node),
-                        },
+                        self.two_way_merge(local_child_node, remote_child_node)
+                    } else {
+                        self.merge_local_node(local_child_node)
                     }?;
                     merged_node.merge_state = merged_node.merge_state.with_new_structure();
                     merged_orphan_node.merge_state =
@@ -1241,17 +1087,17 @@ impl<'t> Merger<'t> {
         for local_child_node in local_parent_node.children() {
             if let Some(local_child_content) =
                 self.new_local_contents
-                    .and_then(|contents| contents.get(&local_child_node.guid()))
+                    .and_then(|contents| contents.get(&local_child_node.guid))
             {
                 if let Some(remote_child_node) =
-                    self.remote_tree.node_for_guid(&local_child_node.guid())
+                    self.remote_tree.node_for_guid(&local_child_node.guid)
                 {
                     trace!("Not deduping local child {}; already exists remotely as {}",
                            local_child_node,
                            remote_child_node);
                     continue;
                 }
-                if self.remote_tree.is_deleted(&local_child_node.guid()) {
+                if self.remote_tree.is_deleted(&local_child_node.guid) {
                     trace!("Not deduping local child {}; deleted remotely",
                            local_child_node);
                     continue;
@@ -1272,7 +1118,7 @@ impl<'t> Merger<'t> {
         let mut remote_to_local = HashMap::new();
 
         for remote_child_node in remote_parent_node.children() {
-            if remote_to_local.contains_key(remote_child_node.guid()) {
+            if remote_to_local.contains_key(&remote_child_node.guid) {
                 trace!("Not deduping remote child {}; already deduped",
                        remote_child_node);
                 continue;
@@ -1282,7 +1128,7 @@ impl<'t> Merger<'t> {
             // were.
             if let Some(remote_child_content) =
                 self.new_remote_contents
-                    .and_then(|contents| contents.get(&remote_child_node.guid()))
+                    .and_then(|contents| contents.get(&remote_child_node.guid))
             {
                 if let Some(mut local_nodes_for_key) =
                     dupe_key_to_local_nodes.get_mut(remote_child_content)
@@ -1291,8 +1137,8 @@ impl<'t> Merger<'t> {
                         trace!("Deduping local child {} to remote child {}",
                                local_child_node,
                                remote_child_node);
-                        local_to_remote.insert(local_child_node.guid().clone(), remote_child_node);
-                        remote_to_local.insert(remote_child_node.guid().clone(), local_child_node);
+                        local_to_remote.insert(local_child_node.guid.clone(), remote_child_node);
+                        remote_to_local.insert(remote_child_node.guid.clone(), local_child_node);
                     } else {
                         trace!("Not deduping remote child {}; no remaining local content matches",
                                remote_child_node);
@@ -1330,7 +1176,7 @@ impl<'t> Merger<'t> {
             let new_remote_node =
                 {
                     let (local_to_remote, _) = matching_dupes_by_local_parent_guid
-                    .entry(local_parent_node.guid().clone())
+                    .entry(local_parent_node.guid.clone())
                     .or_insert_with(|| {
                         trace!("First local child {} doesn't exist remotely; finding all \
                                 matching dupes in local {} and remote {}",
@@ -1342,7 +1188,7 @@ impl<'t> Merger<'t> {
                             remote_parent_node,
                         )
                     });
-                    let new_remote_node = local_to_remote.get(&local_child_node.guid());
+                    let new_remote_node = local_to_remote.get(&local_child_node.guid);
                     new_remote_node.map(|node| {
                         self.structure_counts.dupes += 1;
                         *node
@@ -1377,7 +1223,7 @@ impl<'t> Merger<'t> {
             let new_local_node =
                 {
                     let (_, remote_to_local) = matching_dupes_by_local_parent_guid
-                    .entry(local_parent_node.guid().clone())
+                    .entry(local_parent_node.guid.clone())
                     .or_insert_with(|| {
                         trace!("First remote child {} doesn't exist locally; finding all \
                                 matching dupes in local {} and remote {}",
@@ -1389,7 +1235,7 @@ impl<'t> Merger<'t> {
                             remote_parent_node,
                         )
                     });
-                    let new_local_node = remote_to_local.get(&remote_child_node.guid());
+                    let new_local_node = remote_to_local.get(&remote_child_node.guid);
                     new_local_node.map(|node| {
                         self.structure_counts.dupes += 1;
                         *node

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -176,7 +176,7 @@ impl<'t> Merger<'t> {
             } else {
                 let local_level = self.local_tree
                                       .node_for_guid(guid)
-                                      .map(|node| node.level())
+                                      .and_then(|node| node.level())
                                       .unwrap_or(-1);
                 // Items that should be deleted locally already have tombstones
                 // on the server, so we don't need to upload tombstones for
@@ -192,7 +192,7 @@ impl<'t> Merger<'t> {
         self.delete_remotely.iter().map(move |guid| {
             let local_level = self.local_tree
                                   .node_for_guid(guid)
-                                  .map(|node| node.level())
+                                  .and_then(|node| node.level())
                                   .unwrap_or(-1);
             Deletion { guid: guid.to_owned(),
                        local_level,

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -267,7 +267,7 @@ impl <'t, D: Driver> Merger<'t, D> {
         };
 
         let mut merged_node = MergedNode::new(merged_guid,
-                                              MergeState::Local(local_node));
+                                              MergeState::Local { local_node, remote_node: None });
         if local_node.is_folder() {
             // The local folder doesn't exist remotely, but its children might, so
             // we still need to recursively walk and merge them. This method will
@@ -302,7 +302,7 @@ impl <'t, D: Driver> Merger<'t, D> {
         };
 
         let mut merged_node = MergedNode::new(merged_guid,
-                                              MergeState::Remote(remote_node));
+                                              MergeState::Remote { local_node: None, remote_node });
         if remote_node.is_folder() {
             // As above, a remote folder's children might still exist locally, so we
             // need to merge them and update the merge state from remote to new if
@@ -347,10 +347,10 @@ impl <'t, D: Driver> Merger<'t, D> {
 
         let mut merged_node = MergedNode::new(remote_node.guid.clone(), match item {
             ConflictResolution::Local => {
-                MergeState::Local(local_node)
+                MergeState::Local { local_node, remote_node: Some(remote_node) }
             },
             ConflictResolution::Remote => {
-                MergeState::Remote(remote_node)
+                MergeState::Remote { local_node: Some(local_node), remote_node }
             },
             ConflictResolution::Unchanged => {
                 MergeState::Unchanged { local_node, remote_node }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,28 +1,28 @@
 use std::collections::HashMap;
 
-use error::{ErrorKind, Result};
+use error::{Error, ErrorKind};
 use guid::Guid;
 use merge::{Merger, Deletion};
 use tree::{Content, MergedNode, Tree};
 
-pub trait Store {
+pub trait Store<E: From<Error>> {
     /// Builds a fully rooted, consistent tree from the items and tombstones in
     /// the local store.
-    fn fetch_local_tree(&self, local_time_millis: i64) -> Result<Tree>;
+    fn fetch_local_tree(&self, local_time_millis: i64) -> Result<Tree, E>;
 
     /// Fetches content info for all new local items that haven't been uploaded
     /// or merged yet. We'll try to dedupe them to remotely changed items with
     /// similar contents and different GUIDs.
-    fn fetch_new_local_contents(&self) -> Result<HashMap<Guid, Content>>;
+    fn fetch_new_local_contents(&self) -> Result<HashMap<Guid, Content>, E>;
 
     /// Builds a fully rooted, consistent tree from the items and tombstones in
     /// the mirror.
-    fn fetch_remote_tree(&self, remote_time_millis: i64) -> Result<Tree>;
+    fn fetch_remote_tree(&self, remote_time_millis: i64) -> Result<Tree, E>;
 
     /// Fetches content info for all items in the mirror that changed since the
     /// last sync and don't exist locally. We'll try to match new local items to
     /// these.
-    fn fetch_new_remote_contents(&self) -> Result<HashMap<Guid, Content>>;
+    fn fetch_new_remote_contents(&self) -> Result<HashMap<Guid, Content>, E>;
 
     /// Applies the merged tree and stages items to upload. We keep this
     /// generic: on Desktop, we'll insert the merged tree into a temp
@@ -31,29 +31,28 @@ pub trait Store {
     /// this flow might be simpler.
     fn apply<D: Iterator<Item = Deletion>>(&mut self,
                                            merged_root: &MergedNode,
-                                           deletions: D) -> Result<()>;
-}
+                                           deletions: D) -> Result<(), E>;
 
-pub fn merge<S: Store>(store: &mut S, local_time_millis: i64,
-                       remote_time_millis: i64) -> Result<()> {
-    let local_tree = store.fetch_local_tree(local_time_millis)?;
-    let new_local_contents = store.fetch_new_local_contents()?;
+    fn merge(&mut self, local_time_millis: i64, remote_time_millis: i64) -> Result<(), E> {
+        let local_tree = self.fetch_local_tree(local_time_millis)?;
+        let new_local_contents = self.fetch_new_local_contents()?;
 
-    let remote_tree = store.fetch_remote_tree(remote_time_millis)?;
-    let new_remote_contents = store.fetch_new_remote_contents()?;
+        let remote_tree = self.fetch_remote_tree(remote_time_millis)?;
+        let new_remote_contents = self.fetch_new_remote_contents()?;
 
-    let mut merger = Merger::with_contents(&local_tree, &new_local_contents,
-                                           &remote_tree, &new_remote_contents);
-    let merged_root = merger.merge()?;
+        let mut merger = Merger::with_contents(&local_tree, &new_local_contents,
+                                               &remote_tree, &new_remote_contents);
+        let merged_root = merger.merge()?;
 
-    if !merger.subsumes(&local_tree) {
-        return Err(ErrorKind::UnmergedLocalItems.into());
+        if !merger.subsumes(&local_tree) {
+            Err(E::from(ErrorKind::UnmergedLocalItems.into()))?;
+        }
+        if !merger.subsumes(&remote_tree) {
+            Err(E::from(ErrorKind::UnmergedRemoteItems.into()))?;
+        }
+
+        self.apply(&merged_root, merger.deletions())?;
+
+        Ok(())
     }
-    if !merger.subsumes(&remote_tree) {
-        return Err(ErrorKind::UnmergedRemoteItems.into());
-    }
-
-    store.apply(&merged_root, merger.deletions())?;
-
-    Ok(())
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -23,31 +23,60 @@ use tree::{Content, Item, Kind, Tree};
 
 #[derive(Debug)]
 struct Node {
-    item: Item,
+    info: Info,
     children: Vec<Box<Node>>,
 }
 
 impl Node {
-    fn new(item: Item) -> Node {
-        Node { item, children: Vec::new() }
+    fn new(info: Info) -> Node {
+        Node { info, children: Vec::new() }
     }
 
     fn into_tree(self) -> Result<Tree> {
         fn inflate(tree: &mut Tree, parent_guid: &Guid, node: Node) -> Result<()> {
-            let guid = node.item.guid.clone();
-            tree.insert(&parent_guid, node.item)?;
+            let item = Item::Existing {
+                guid: node.info.guid.clone(),
+                parent_guid: Some(parent_guid.clone()),
+                kind: node.info.kind,
+                age: node.info.age,
+                needs_merge: node.info.needs_merge,
+            };
+            tree.insert(&parent_guid, item)?;
             for child in node.children {
-                inflate(tree, &guid, *child)?;
+                inflate(tree, &node.info.guid, *child)?;
             }
             Ok(())
         }
 
-        let guid = self.item.guid.clone();
-        let mut tree = Tree::new(self.item);
+        let item = Item::Existing {
+            guid: self.info.guid.clone(),
+            parent_guid: None,
+            kind: self.info.kind,
+            age: self.info.age,
+            needs_merge: self.info.needs_merge,
+        };
+        let mut tree = Tree::new(item);
         for child in self.children {
-            inflate(&mut tree, &guid, *child)?;
+            inflate(&mut tree, &self.info.guid, *child)?;
         }
         Ok(tree)
+    }
+}
+
+#[derive(Debug)]
+struct Info {
+    guid: Guid,
+    kind: Kind,
+    age: i64,
+    needs_merge: bool,
+}
+
+impl Info {
+    pub fn new(guid: Guid, kind: Kind) -> Info {
+        Info { guid,
+               kind,
+               age: 0,
+               needs_merge: false, }
     }
 }
 
@@ -55,9 +84,9 @@ macro_rules! nodes {
     ($children:tt) => { nodes!(ROOT_GUID, Folder[needs_merge = true], $children) };
     ($guid:expr, $kind:ident) => { nodes!(Guid::from($guid), $kind[]) };
     ($guid:expr, $kind:ident [ $( $name:ident = $value:expr ),* ]) => {{
-        let mut item = Item::new(Guid::from($guid), Kind::$kind);
-        $({ item.$name = $value; })*
-        Node::new(item)
+        let mut info = Info::new(Guid::from($guid), Kind::$kind);
+        $({ info.$name = $value; })*
+        Node::new(info)
     }};
     ($guid:expr, $kind:ident, $children:tt) => { nodes!($guid, $kind[], $children) };
     ($guid:expr, $kind:ident [ $( $name:ident = $value:expr ),* ], { $(( $($children:tt)+ )),* }) => {{

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -44,7 +44,7 @@ impl Node {
             tree.insert(ParentGuidFrom::default()
                             .children(&parent_guid)
                             .item(&parent_guid),
-                        item)?;
+                        item.into())?;
             for child in node.children {
                 inflate(tree, &node.info.guid, *child)?;
             }
@@ -1991,14 +1991,14 @@ fn reparent_orphans() {
         kind: Kind::Bookmark,
         age: 0,
         needs_merge: true,
-    }).expect("Should insert orphan E");
+    }.into()).expect("Should insert orphan E");
     remote_tree.insert(ParentGuidFrom::default().item(&"nonexistent".into()), Item::Existing {
         guid: "bookmarkFFFF".into(),
         parent_guid: None,
         kind: Kind::Bookmark,
         age: 0,
         needs_merge: true,
-    }).expect("Should insert orphan F");
+    }.into()).expect("Should insert orphan F");
 
     let mut merger = Merger::new(&local_tree, &remote_tree);
     let merged_root = merger.merge().unwrap();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1845,7 +1845,7 @@ fn invalid_guids() {
     }).into_tree().unwrap();
     let new_remote_contents: HashMap<Guid, Content> = HashMap::new();
 
-    let mut merger = Merger::with_driver(&AllowInvalidGuids,
+    let mut merger = Merger::with_driver(AllowInvalidGuids,
                                          &local_tree,
                                          &new_local_contents,
                                          &remote_tree,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -19,7 +19,7 @@ use std::{collections::HashMap, sync::Once};
 use error::{ErrorKind, Result};
 use guid::{Guid, ROOT_GUID};
 use merge::{Merger, StructureCounts};
-use tree::{Content, Item, Kind, Tree};
+use tree::{Content, Item, Kind, ParentGuidFrom, Tree};
 
 #[derive(Debug)]
 struct Node {
@@ -41,7 +41,10 @@ impl Node {
                 age: node.info.age,
                 needs_merge: node.info.needs_merge,
             };
-            tree.insert(&parent_guid, item)?;
+            tree.insert(ParentGuidFrom::default()
+                            .children(&parent_guid)
+                            .item(&parent_guid),
+                        item)?;
             for child in node.children {
                 inflate(tree, &node.info.guid, *child)?;
             }


### PR DESCRIPTION
In a well-formed tree:

- Each item exists in exactly one folder. Two different folder's
  `children` should never reference the same item.
- Each folder contains existing children. A folder's `children` should
  never reference tombstones, or items that don't exist in the tree at all.
- Each item has a `parentid` that agrees with its parent's `children`. In
  other words, if item B's `parentid` is A, then A's `children` should
  contain B.

Because of Reasons, things are (a lot) messier in practice.

# Structure inconsistencies

Sync stores structure in two places: a `parentid` property on each item,
which points to its parent's GUID, and a list of ordered `children` on the
item's parent. They're duplicated because, historically, Sync clients didn't
stage incoming records. Instead, they applied records one at a time,
directly to the live local tree. This meant that, if a client saw a child
before its parent, it would first use the `parentid` to decide where to keep
the child, then fix up parents and positions using the parent's `children`.

This is also why moving an item into a different folder uploads records for
the item, old folder, and new folder. The item has a new `parentid`, and the
folders have new `children`. Similarly, deleting an item uploads a tombstone
for the item, and a record for the item's old parent.

Unfortunately, bugs (bug 1258127) and missing features (bug 1253051) in
older clients sometimes caused them to upload invalid or incomplete changes.
For example, a client might have:

- Uploaded a moved child, but not its parents. This means the child now
  appears in multiple parents. In the most extreme case, an item might be
  referenced in two different sets of `children`, _and_ have a third,
  completely unrelated `parentid`.
- Deleted a child, and tracked the deletion, but didn't flag the parent for
  reupload. The parent folder now has a tombstone child.
- Tracked and uploaded items that shouldn't exist on the server at all,
  like the left pane or reading list roots (bug 1309255).
- Missed new folders created during a sync, creating holes in the tree.

Newer clients shouldn't do this, but we might still have inconsistent
records on the server that will confuse older clients. Additionally, Firefox
for iOS includes a much stricter bookmarks engine that refuses to sync if
it detects inconsistencies.

# Divergences

To work around this, our tree lets the structure _diverge_. This allows:

- Items with multiple parents.
- Items with missing `parentid`s.
- Folders with `children` whose `parentid`s don't match the folder.
- Items whose `parentid`s don't mention the item in their `children`.
- Items with `parentid`s that point to nonexistent or deleted folders.
- Folders with nonexistent `children`.
- Non-syncable items, like custom roots.
- Any combination of these.

Each item in the tree has an `EntryParentFrom` tag that indicates where
its structure comes from. Structure from `children` is validated and
resolved at `insert` time, so trying to add an item to a parent that
doesn't exist or isn't a folder returns a `MissingParent` or
`InvalidParent` error.

Structure from `parentid`, if it diverges from `children`, is resolved at
merge time, when the merger walks the complete tree. You can think of this
distinction as similar to early vs. late binding. The `parentid`, if
different from the parent's `children`, might not exist in the tree at
`insert` time, either because the parent hasn't been added yet, or because
it doesn't exist in the tree at all.

# Resolving divergences

Walking the tree, using `Tree::node_for_guid`, `Node::parent`, and
`Node::children`, resolves divergences using these rules:

1. Items that appear in multiple `children`, and items with mismatched
   `parentid`s, use the chronologically newer parent, based on the parent's
   last modified time. We always prefer structure from `children` over
   `parentid,` because `children` also gives us the item's position.
2. Items that aren't mentioned in any parent's `children`, but have a
   `parentid` that references an existing folder in the tree, are reparented
   to the end of that folder, after the folder's `children`.
3. Items that reference a nonexistent or non-folder `parentid`, or don't
   have a `parentid` at all, are reparented to the default folder, after any
   `children` and items from rule 2.
4. If the default folder isn't set, or doesn't exist, items from rule 3 are
   reparented to the root instead.

The result is a well-formed tree structure that can be merged. The merger
detects if the structure diverged, and flags affected items for reupload.

Closes #18.