### PR TITLE
Replace `log` with a simple local logger

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,3 @@ repository = "https://github.com/linacambridge/dogear"
 authors = ["Lina Cambridge <lina@mozilla.com>"]
 license = "Apache-2.0"
 exclude = [".travis", ".travis.yml"]
-
-[dependencies]
-log = "0.4"
-
-[dev-dependencies]
-env_logger = "0.5.6"

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,0 +1,77 @@
+// Copyright 2018 Mozilla
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::Arguments;
+
+use crate::error::{ErrorKind, Result};
+use crate::guid::Guid;
+
+/// A merge driver provides methods to customize merging behavior.
+pub trait Driver {
+    /// Generates a new GUID for the given invalid GUID. This is used to fix up
+    /// items with GUIDs that Places can't store (bug 1380606, bug 1313026).
+    ///
+    /// The default implementation returns an error, forbidding invalid GUIDs.
+    ///
+    /// Implementations of `Driver` can either use the `rand` and `base64`
+    /// crates to generate a new, random GUID (9 bytes, Base64url-encoded
+    /// without padding), or use an existing method like Desktop's
+    /// `nsINavHistoryService::MakeGuid`. Dogear doesn't generate new GUIDs
+    /// automatically to avoid depending on those crates.
+    ///
+    /// Implementations can also return `Ok(invalid_guid.clone())` to pass
+    /// through all invalid GUIDs, as the tests do.
+    fn generate_new_guid(&self, invalid_guid: &Guid) -> Result<Guid> {
+        Err(ErrorKind::InvalidGuid(invalid_guid.clone()).into())
+    }
+
+    /// Returns the maximum level for log messages.
+    fn log_level(&self) -> LogLevel {
+        LogLevel::Silent
+    }
+
+    /// Logs a message at the given log level.
+    fn log(&self, _level: LogLevel, _args: Arguments) {}
+}
+
+/// A default implementation of the merge driver.
+pub struct DefaultDriver;
+
+impl Driver for DefaultDriver {}
+
+#[derive(Eq, Ord, PartialEq, PartialOrd)]
+pub enum LogLevel {
+    Silent,
+    Error,
+    Trace,
+    All,
+}
+
+#[macro_export]
+macro_rules! trace {
+    ($driver:expr, $($args:tt)+) => {
+        if $driver.log_level() >= $crate::driver::LogLevel::Trace {
+            $driver.log($crate::driver::LogLevel::Trace, format_args!($($args)+))
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! error {
+    ($driver:expr, $($args:tt)+) => {
+        if $driver.log_level() >= $crate::driver::LogLevel::Error {
+            $driver.log($crate::driver::LogLevel::Error, format_args!($($args)+))
+        }
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 #[macro_use]
-extern crate log;
-
+mod driver;
 mod error;
 mod guid;
 mod merge;
@@ -24,6 +23,7 @@ mod tree;
 #[cfg(test)]
 mod tests;
 
+pub use crate::driver::{DefaultDriver, Driver, LogLevel};
 pub use crate::error::{Error, ErrorKind, Result};
 pub use crate::guid::{Guid, ROOT_GUID, USER_CONTENT_ROOTS};
 pub use crate::merge::{Deletion, Merger, StructureCounts};

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate env_logger;
+use std::collections::HashMap;
 
-use std::{collections::HashMap, sync::Once};
-
+use crate::driver::Driver;
 use crate::error::{ErrorKind, Result};
 use crate::guid::{Guid, ROOT_GUID, UNFILED_GUID};
-use crate::merge::{Driver, Merger, StructureCounts};
+use crate::merge::{Merger, StructureCounts};
 use crate::tree::{Content, Item, Kind, ParentGuidFrom, Tree};
 
 #[derive(Debug)]
@@ -73,12 +72,7 @@ macro_rules! nodes {
     }};
 }
 
-fn before_each() {
-    static ONCE: Once = Once::new();
-    ONCE.call_once(|| {
-                       env_logger::init();
-                   });
-}
+fn before_each() {}
 
 #[test]
 fn reparent_and_reposition() {
@@ -1845,7 +1839,7 @@ fn invalid_guids() {
     }).into_tree().unwrap();
     let new_remote_contents: HashMap<Guid, Content> = HashMap::new();
 
-    let mut merger = Merger::with_driver(AllowInvalidGuids,
+    let mut merger = Merger::with_driver(&AllowInvalidGuids,
                                          &local_tree,
                                          &new_local_contents,
                                          &remote_tree,


### PR DESCRIPTION
The `log` crate uses a global logger that can only be registered once,
at startup. Unfortunately, this won't work for Desktop, where we want
to integrate with Sync's existing logging setup. We also don't want to
impact other crates in `gkrust` that use `log`.

This commit replaces `log` with a quick-and-dirty implementation on
`Driver`, and some macros that take care of calling `format_args!()`.
We can extend these later to pass `file!()` and `line!()`, if we
want.

This commit also changes `Merger` to hold a reference to `Driver`.
On Desktop, the driver accumulates log messages on the storage
thread, and accesses them on the main thread.