### PR TITLE
Replant the tree! 🌲

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ authors = ["Lina Cambridge <lina@mozilla.com>"]
 license = "Apache-2.0"
 exclude = [".travis", ".travis.yml"]
 edition = "2018"
+
+[dependencies]
+smallbitvec = "2.3.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -76,6 +76,9 @@ impl fmt::Display for Error {
                 write!(f, "Can't insert item {} into nonexistent parent {}",
                        child_guid, parent_guid)
             },
+            ErrorKind::Cycle(guid) => {
+                write!(f, "Item {} can't contain itself", guid)
+            },
             ErrorKind::MergeConflict => {
                 write!(f, "Local tree changed during merge")
             },
@@ -103,6 +106,7 @@ pub enum ErrorKind {
     InvalidParent(Guid, Guid),
     MissingParent(Guid, Guid),
     MissingItem(Guid),
+    Cycle(Guid),
     MergeConflict,
     UnmergedLocalItems,
     UnmergedRemoteItems,

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,6 +65,9 @@ impl fmt::Display for Error {
             ErrorKind::DuplicateItem(guid) => {
                 write!(f, "Item {} already exists in tree", guid)
             },
+            ErrorKind::MissingItem(guid) => {
+                write!(f, "Item {} doesn't exist in tree", guid)
+            },
             ErrorKind::InvalidParent(child_guid, parent_guid) => {
                 write!(f, "Can't insert item {} into non-folder {}",
                        child_guid, parent_guid)
@@ -99,6 +102,7 @@ pub enum ErrorKind {
     DuplicateItem(Guid),
     InvalidParent(Guid, Guid),
     MissingParent(Guid, Guid),
+    MissingItem(Guid),
     MergeConflict,
     UnmergedLocalItems,
     UnmergedRemoteItems,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ mod tests;
 
 pub use crate::driver::{DefaultDriver, Driver, LogLevel};
 pub use crate::error::{Error, ErrorKind, Result};
-pub use crate::guid::{Guid, ROOT_GUID, USER_CONTENT_ROOTS};
+pub use crate::guid::{Guid, ROOT_GUID, UNFILED_GUID, USER_CONTENT_ROOTS};
 pub use crate::merge::{Deletion, Merger, StructureCounts};
 pub use crate::store::{MergeTimings, Stats, Store};
-pub use crate::tree::{Child, Content, Item, Kind, Validity, MergedDescendant, MergeState, MergedNode, ParentGuidFrom, Tree, UploadReason};
+pub use crate::tree::{Content, IntoTree, Item, Kind, Validity, MergedDescendant, MergeState, MergedNode, Tree, UploadReason};

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -19,6 +19,8 @@ use std::{cmp::Ordering,
           ops::Deref,
           ptr};
 
+use smallbitvec::SmallBitVec;
+
 use crate::error::{ErrorKind, Result};
 use crate::guid::{Guid, ROOT_GUID};
 
@@ -760,7 +762,7 @@ impl ResolvedParent {
 /// algorithm. Returns the index of the entry where the cycle was detected,
 /// or `None` if there aren't any cycles.
 fn detect_cycles(parents: &[ResolvedParent]) -> Option<Index> {
-    let mut seen = vec![false; parents.len()];
+    let mut seen = SmallBitVec::from_elem(parents.len(), false);
     for (entry_index, parent) in parents.iter().enumerate() {
         if seen[entry_index] {
             continue;
@@ -780,7 +782,7 @@ fn detect_cycles(parents: &[ResolvedParent]) -> Option<Index> {
                 .and_then(|index| parents[index].index())
                 .and_then(|index| parents[index].index());
         }
-        seen[entry_index] = true;
+        seen.set(entry_index, true);
     }
     None
 }


### PR DESCRIPTION
This started out as a fix for corruption corner cases, grew into
simplifying how we build the remote tree, and turned into a rewrite
(again >.>). Instead of managing two different sets of structure at
insert and merge time, we now store items and parent-child
relationships in a tree builder, then build a consistent tree that
flags divergent items.

The old tree was complicated because it had to maintain a valid
structure before and after every insert, but with references to
potentially unknown parents and children. Since we couldn't insert
an item without knowing its parent, we had to pick a canonical
structure (parents by `children`), insert children in level
order, and note divergent structure (by `parentid`) separately.

This meant Desktop's `Store::fetch_remote_tree()` had to left-join
`mirror.items` to `mirror.structure`, store the items in a
pseudo-tree, then recursively walk children to inflate the complete
tree. This was complicated enough with a valid tree, let alone
orphans and multiple parents.

With the new approach, we build the tree in three steps:

1. First, we add all items, without structure.
2. Next, we set parent-child relationships. Parents by `children`
   require the parent to exist, but not the child; this handles the
   case where a folder mentions nonexistent or deleted GUIDs in
   its `children`. Parents by `parentid` require the item to exist,
   but not its parent; this handles orphans that reference missing
   or non-folder parents.
3. Finally, once we've added all entries to the tree, we have a
   complete view of the structure, so we can resolve missing, multiple,
   and conflicting parents.

For cases where we know the structure is valid and in level order,
like Desktop's `Store::fetch_local_tree()`, we handle steps 1 and 2
at the same time: `builder.item(item)?.by_structure(&parent_guid)?`.

For the remote tree, we insert all items and their `parentid`s
first (`builder.item(item)?.by_parent_guid(&parent_guid)?`, where
`parent_guid` might not be in the tree), then add structure from
children later:
`builder.parent_for(&child_guid)?.by_children(&parent_guid)?`,
where `child_guid` might not be in the tree.

Closes #22.