### PR TITLE
Keep both local and remote nodes with mismatched kinds

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -62,7 +62,7 @@ pub enum LogLevel {
 macro_rules! trace {
     ($driver:expr, $($args:tt)+) => {
         if $driver.log_level() >= $crate::driver::LogLevel::Trace {
-            $driver.log($crate::driver::LogLevel::Trace, format_args!($($args)+))
+            $driver.log($crate::driver::LogLevel::Trace, format_args!($($args)+));
         }
     };
 }
@@ -71,7 +71,7 @@ macro_rules! trace {
 macro_rules! error {
     ($driver:expr, $($args:tt)+) => {
         if $driver.log_level() >= $crate::driver::LogLevel::Error {
-            $driver.log($crate::driver::LogLevel::Error, format_args!($($args)+))
+            $driver.log($crate::driver::LogLevel::Error, format_args!($($args)+));
         }
     };
 }

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -54,6 +54,7 @@ impl Driver for DefaultDriver {}
 pub enum LogLevel {
     Silent,
     Error,
+    Warn,
     Trace,
     All,
 }
@@ -63,6 +64,15 @@ macro_rules! trace {
     ($driver:expr, $($args:tt)+) => {
         if $driver.log_level() >= $crate::driver::LogLevel::Trace {
             $driver.log($crate::driver::LogLevel::Trace, format_args!($($args)+));
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! warn {
+    ($driver:expr, $($args:tt)+) => {
+        if $driver.log_level() >= $crate::driver::LogLevel::Warn {
+            $driver.log($crate::driver::LogLevel::Warn, format_args!($($args)+));
         }
     };
 }

--- a/src/guid.rs
+++ b/src/guid.rs
@@ -141,6 +141,17 @@ impl<T: Copy + Into<usize>> IsValidGuid for [T] {
     }
 }
 
+impl From<String> for Guid {
+    #[inline]
+    fn from(s: String) -> Guid {
+        if s.as_bytes().is_valid_guid() {
+            Guid::from(s.as_str())
+        } else {
+            Guid(Repr::Slow(s))
+        }
+    }
+}
+
 impl<'a> From<&'a str> for Guid {
     #[inline]
     fn from(s: &'a str) -> Guid {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,4 +28,4 @@ pub use crate::error::{Error, ErrorKind, Result};
 pub use crate::guid::{Guid, ROOT_GUID, USER_CONTENT_ROOTS};
 pub use crate::merge::{Deletion, Merger, StructureCounts};
 pub use crate::store::Store;
-pub use crate::tree::{Child, Content, Item, Kind, MergeState, MergedNode, ParentGuidFrom, Tree, Descendant};
+pub use crate::tree::{Child, Content, Item, Kind, Validity, MergeState, MergedNode, ParentGuidFrom, Tree, Descendant};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,4 +28,4 @@ pub use crate::error::{Error, ErrorKind, Result};
 pub use crate::guid::{Guid, ROOT_GUID, USER_CONTENT_ROOTS};
 pub use crate::merge::{Deletion, Merger, StructureCounts};
 pub use crate::store::Store;
-pub use crate::tree::{Child, Content, Item, Kind, Validity, MergeState, MergedNode, ParentGuidFrom, Tree, Descendant};
+pub use crate::tree::{Child, Content, Item, Kind, Validity, MergedDescendant, MergeState, MergedNode, ParentGuidFrom, Tree};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,4 +28,4 @@ pub use crate::error::{Error, ErrorKind, Result};
 pub use crate::guid::{Guid, ROOT_GUID, USER_CONTENT_ROOTS};
 pub use crate::merge::{Deletion, Merger, StructureCounts};
 pub use crate::store::Store;
-pub use crate::tree::{Child, Content, Item, Kind, MergeState, MergedNode, ParentGuidFrom, Tree};
+pub use crate::tree::{Child, Content, Item, Kind, MergeState, MergedNode, ParentGuidFrom, Tree, Descendant};

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -714,31 +714,27 @@ impl <'t, D: Driver> Merger<'t, D> {
         }
 
         match (local_node.needs_merge, remote_node.needs_merge) {
-            (true, true) => match (local_node.diverged(), remote_node.diverged()) {
-                (true, false) => (ConflictResolution::Remote, ConflictResolution::Remote),
-                (false, true) => (ConflictResolution::Local, ConflictResolution::Local),
-                _ => {
-                    // The item changed locally and remotely.
-                    let newer_side = if local_node.age < remote_node.age {
-                        // The local change is newer, so merge local children first,
-                        // followed by remaining unmerged remote children.
-                        ConflictResolution::Local
-                    } else {
-                        // The remote change is newer, so walk and merge remote
-                        // children first, then remaining local children.
-                        ConflictResolution::Remote
-                    };
-                    if local_node.is_user_content_root() {
-                        // For roots, we always prefer the local side for item
-                        // changes, like the title (bug 1432614), but prefer the
-                        // newer side for children.
-                        (ConflictResolution::Local, newer_side)
-                    } else {
-                        // For all other items, we prefer the newer side for the
-                        // item and children.
-                        (newer_side, newer_side)
-                    }
-                },
+            (true, true) => {
+                // The item changed locally and remotely.
+                let newer_side = if local_node.age < remote_node.age {
+                    // The local change is newer, so merge local children first,
+                    // followed by remaining unmerged remote children.
+                    ConflictResolution::Local
+                } else {
+                    // The remote change is newer, so walk and merge remote
+                    // children first, then remaining local children.
+                    ConflictResolution::Remote
+                };
+                if local_node.is_user_content_root() {
+                    // For roots, we always prefer the local side for item
+                    // changes, like the title (bug 1432614), but prefer the
+                    // newer side for children.
+                    (ConflictResolution::Local, newer_side)
+                } else {
+                    // For all other items, we prefer the newer side for the
+                    // item and children.
+                    (newer_side, newer_side)
+                }
             },
 
             (true, false) => {
@@ -782,21 +778,17 @@ impl <'t, D: Driver> Merger<'t, D> {
         }
 
         match (local_parent_node.needs_merge, remote_parent_node.needs_merge) {
-            (true, true) => match (local_parent_node.diverged(), remote_parent_node.diverged()) {
-                (true, false) => ConflictResolution::Remote,
-                (false, true) => ConflictResolution::Local,
-                _ => {
-                    // If both parents changed, compare timestamps to decide where
-                    // to keep the local child.
-                    let latest_local_age = local_child_node.age.min(local_parent_node.age);
-                    let latest_remote_age = remote_child_node.age.min(remote_parent_node.age);
+            (true, true) => {
+                // If both parents changed, compare timestamps to decide where
+                // to keep the local child.
+                let latest_local_age = local_child_node.age.min(local_parent_node.age);
+                let latest_remote_age = remote_child_node.age.min(remote_parent_node.age);
 
-                    if latest_local_age < latest_remote_age {
-                        ConflictResolution::Local
-                    } else {
-                        ConflictResolution::Remote
-                    }
-                },
+                if latest_local_age < latest_remote_age {
+                    ConflictResolution::Local
+                } else {
+                    ConflictResolution::Remote
+                }
             },
 
             // If only the local or remote parent changed, keep the child in its

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -17,7 +17,7 @@ use std::{collections::{HashMap, HashSet, VecDeque},
 
 use crate::driver::{DefaultDriver, Driver};
 use crate::error::{ErrorKind, Result};
-use crate::guid::Guid;
+use crate::guid::{Guid, IsValid};
 use crate::tree::{Content, MergeState, MergedNode, Node, Tree};
 
 /// Structure change types, used to indicate if a node on one side is moved
@@ -228,7 +228,7 @@ impl <'t, D: Driver> Merger<'t, D> {
 
         self.merged_guids.insert(local_node.guid.clone());
 
-        let merged_guid = if local_node.guid.valid() {
+        let merged_guid = if local_node.guid.is_valid() {
             local_node.guid.clone()
         } else {
             let new_guid = self.driver.generate_new_guid(&local_node.guid)?;
@@ -260,7 +260,7 @@ impl <'t, D: Driver> Merger<'t, D> {
 
         self.merged_guids.insert(remote_node.guid.clone());
 
-        let merged_guid = if remote_node.guid.valid() {
+        let merged_guid = if remote_node.guid.is_valid() {
             remote_node.guid.clone()
         } else {
             let new_guid = self.driver.generate_new_guid(&remote_node.guid)?;

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -17,7 +17,7 @@ use std::{collections::{HashMap, HashSet, VecDeque},
 
 use crate::driver::{DefaultDriver, Driver};
 use crate::error::{ErrorKind, Result};
-use crate::guid::{Guid, IsValid};
+use crate::guid::{Guid, IsValidGuid};
 use crate::tree::{Content, MergeState, MergedNode, Node, Tree, Validity};
 
 /// Structure change types, used to indicate if a node on one side is moved
@@ -228,7 +228,7 @@ impl <'t, D: Driver> Merger<'t, D> {
 
         self.merged_guids.insert(local_node.guid.clone());
 
-        let merged_guid = if local_node.guid.is_valid() {
+        let merged_guid = if local_node.guid.is_valid_guid() {
             local_node.guid.clone()
         } else {
             let new_guid = self.driver.generate_new_guid(&local_node.guid)?;
@@ -260,7 +260,7 @@ impl <'t, D: Driver> Merger<'t, D> {
 
         self.merged_guids.insert(remote_node.guid.clone());
 
-        let merged_guid = if remote_node.guid.is_valid() {
+        let merged_guid = if remote_node.guid.is_valid_guid() {
             remote_node.guid.clone()
         } else {
             let new_guid = self.driver.generate_new_guid(&remote_node.guid)?;

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -96,8 +96,8 @@ pub struct Merger<'t, D = DefaultDriver> {
     new_remote_contents: Option<&'t HashMap<Guid, Content>>,
     matching_dupes_by_local_parent_guid: HashMap<Guid, MatchingDupes<'t>>,
     merged_guids: HashSet<Guid>,
-    delete_locally: HashSet<Guid>,
-    delete_remotely: HashSet<Guid>,
+    pub(crate) delete_locally: HashSet<Guid>,
+    pub(crate) delete_remotely: HashSet<Guid>,
     structure_counts: StructureCounts,
 }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -48,7 +48,20 @@ pub trait Store<D: Driver, E: From<Error>> {
                                              &remote_tree, &new_remote_contents);
         let merged_root = merger.merge()?;
         if driver.log_level() >= LogLevel::Trace {
-            trace!(driver, "Built new merged tree\n{}", merged_root.to_ascii_string());
+            let delete_locally = merger
+                .delete_locally
+                .iter()
+                .map(|guid| guid.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            let delete_remotely = merger
+                .delete_remotely
+                .iter()
+                .map(|guid| guid.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            trace!(driver, "Built new merged tree\n{}\nDelete Locally: [{}]\nDelete Remotely: [{}]",
+                   merged_root.to_ascii_string(), delete_locally, delete_remotely);
         }
 
         if !merger.subsumes(&local_tree) {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -169,7 +169,7 @@ fn move_into_parent_sibling() {
     assert!(merger.subsumes(&remote_tree));
 
     let expected_tree = nodes!({
-        ("menu________", Folder, {
+        ("menu________", Folder[needs_merge = true], {
             ("folderAAAAAA", Folder),
             ("folderCCCCCC", Folder, {
                 ("bookmarkBBBB", Bookmark)
@@ -429,7 +429,7 @@ fn newer_local_moves() {
             ("folderHHHHHH", Folder[needs_merge = true], {
                 ("bookmarkGGGG", Bookmark[needs_merge = true])
             }),
-            ("folderFFFFFF", Folder),
+            ("folderFFFFFF", Folder[needs_merge = true]),
             ("bookmarkEEEE", Bookmark[age = 10])
         }),
         ("unfiled_____", Folder[needs_merge = true], {
@@ -518,22 +518,22 @@ fn newer_remote_moves() {
     assert!(merger.subsumes(&remote_tree));
 
     let expected_tree = nodes!({
-        ("menu________", Folder[age = 5], {
+        ("menu________", Folder[needs_merge = true, age = 5], {
             ("folderDDDDDD", Folder, {
                 ("bookmarkGGGG", Bookmark)
             })
         }),
-        ("toolbar_____", Folder[age = 5], {
+        ("toolbar_____", Folder[needs_merge = true, age = 5], {
             ("folderFFFFFF", Folder),
             ("bookmarkEEEE", Bookmark[age = 10]),
             ("folderHHHHHH", Folder, {
                 ("bookmarkCCCC", Bookmark)
             })
         }),
-        ("unfiled_____", Folder[age = 5], {
+        ("unfiled_____", Folder[needs_merge = true, age = 5], {
             ("folderBBBBBB", Folder)
         }),
-        ("mobile______", Folder[age = 5], {
+        ("mobile______", Folder[needs_merge = true, age = 5], {
             ("bookmarkAAAA", Bookmark)
         })
     }).into_tree().unwrap();
@@ -958,7 +958,7 @@ fn nonexistent_on_one_side() {
     assert!(merger.subsumes(&local_tree));
     assert!(merger.subsumes(&remote_tree));
 
-    let expected_tree = Tree::default();
+    let expected_tree = nodes!({}).into_tree().unwrap();
     let expected_deletions = vec![
         "bookmarkAAAA",
         "bookmarkBBBB",
@@ -1184,8 +1184,8 @@ fn deduping_local_newer() {
 
     let expected_tree = nodes!({
         ("menu________", Folder[needs_merge = true], {
-            ("bookmarkAAAA", Bookmark),
-            ("bookmarkAAA4", Bookmark),
+            ("bookmarkAAAA", Bookmark[needs_merge = true]),
+            ("bookmarkAAA4", Bookmark[needs_merge = true]),
             ("bookmarkAAA3", Bookmark[needs_merge = true]),
             ("bookmarkAAA5", Bookmark)
         })
@@ -1299,7 +1299,7 @@ fn deduping_remote_newer() {
     assert!(merger.subsumes(&remote_tree));
 
     let expected_tree = nodes!({
-        ("menu________", Folder[age = 5], {
+        ("menu________", Folder[needs_merge = true, age = 5], {
             ("folderAAAAAA", Folder[needs_merge = true], {
                 ("bookmarkBBBB", Bookmark[age = 10]),
                 ("bookmarkCCC1", Bookmark),
@@ -1411,12 +1411,12 @@ fn complex_deduping() {
     assert!(merger.subsumes(&remote_tree));
 
     let expected_tree = nodes!({
-        ("menu________", Folder, {
+        ("menu________", Folder[needs_merge = true], {
             ("folderAAAAA1", Folder[needs_merge = true], {
                 ("bookmarkBBB1", Bookmark),
                 ("bookmarkCCCC", Bookmark[needs_merge = true, age = 10])
             }),
-            ("folderDDDDD1", Folder, {
+            ("folderDDDDD1", Folder[needs_merge = true], {
                 ("bookmarkEEE1", Bookmark)
             }),
             ("folderFFFFF1", Folder, {
@@ -1597,7 +1597,7 @@ fn applying_two_empty_folders_doesnt_smush() {
     assert!(merger.subsumes(&local_tree));
     assert!(merger.subsumes(&remote_tree));
 
-    let expected_tree = nodes!(ROOT_GUID, Folder, {
+    let expected_tree = nodes!({
         ("mobile______", Folder, {
             ("emptyempty01", Folder),
             ("emptyempty02", Folder)
@@ -1653,7 +1653,7 @@ fn applying_two_empty_folders_matches_only_one() {
     assert!(merger.subsumes(&remote_tree));
 
     let expected_tree = nodes!({
-        ("mobile______", Folder, {
+        ("mobile______", Folder[needs_merge = true], {
             ("emptyempty01", Folder),
             ("emptyempty02", Folder),
             ("emptyempty03", Folder)
@@ -1714,7 +1714,7 @@ fn deduping_ignores_parent_title() {
     assert!(merger.subsumes(&remote_tree));
 
     let expected_tree = nodes!({
-        ("mobile______", Folder, {
+        ("mobile______", Folder[needs_merge = true], {
             ("bookmarkAAAA", Bookmark)
         })
     }).into_tree().unwrap();
@@ -1758,8 +1758,8 @@ fn mismatched_compatible_bookmark_kinds() {
     assert!(merger.subsumes(&remote_tree));
 
     let expected_tree = nodes!({
-        ("menu________", Folder, {
-            ("queryAAAAAAA", Query),
+        ("menu________", Folder[needs_merge = true], {
+            ("queryAAAAAAA", Query[needs_merge = true]),
             ("bookmarkBBBB", Query)
         })
     }).into_tree().unwrap();
@@ -1901,7 +1901,7 @@ fn multiple_parents() {
     assert!(merger.subsumes(&local_tree));
     assert!(merger.subsumes(&remote_tree));
 
-    let expected_tree = nodes!(ROOT_GUID, Folder, {
+    let expected_tree = nodes!({
         ("toolbar_____", Folder[age = 5, needs_merge = true], {
             ("bookmarkBBBB", Bookmark)
         }),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -18,7 +18,7 @@ use crate::driver::Driver;
 use crate::error::{ErrorKind, Result};
 use crate::guid::{Guid, ROOT_GUID, UNFILED_GUID};
 use crate::merge::{Merger, StructureCounts};
-use crate::tree::{Content, Item, Kind, ParentGuidFrom, Tree};
+use crate::tree::{Content, Item, Kind, ParentGuidFrom, Tree, Validity};
 
 #[derive(Debug)]
 struct Node {
@@ -1955,12 +1955,14 @@ fn reparent_orphans() {
         kind: Kind::Bookmark,
         age: 0,
         needs_merge: true,
+        validity: Validity::Valid,
     }.into()).expect("Should insert orphan E");
     remote_tree.insert(ParentGuidFrom::default().item(&"nonexistent".into()), Item {
         guid: "bookmarkFFFF".into(),
         kind: Kind::Bookmark,
         age: 0,
         needs_merge: true,
+        validity: Validity::Valid,
     }.into()).expect("Should insert orphan F");
 
     let mut merger = Merger::new(&local_tree, &remote_tree);

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -948,6 +948,7 @@ pub struct Item {
     pub kind: Kind,
     pub age: i64,
     pub needs_merge: bool,
+    pub validity: Validity,
 }
 
 impl Item {
@@ -955,7 +956,8 @@ impl Item {
         Item { guid,
                kind,
                age: 0,
-               needs_merge: false, }
+               needs_merge: false,
+               validity: Validity::Valid }
     }
 
     #[inline]
@@ -977,10 +979,14 @@ impl Item {
 
 impl fmt::Display for Item {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let kind = match self.validity {
+            Validity::Valid => format!("{}", self.kind),
+            Validity::Reupload | Validity::Replace => format!("{} ({})", self.kind, self.validity),
+        };
         let info = if self.needs_merge {
-            format!("{}; Age = {}ms; Unmerged", self.kind, self.age)
+            format!("{}; Age = {}ms; Unmerged", kind, self.age)
         } else {
-            format!("{}; Age = {}ms", self.kind, self.age)
+            format!("{}; Age = {}ms", kind, self.age)
         };
         write!(f, "{} ({})", self.guid, info)
     }
@@ -997,6 +1003,20 @@ pub enum Kind {
 }
 
 impl fmt::Display for Kind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+/// Synced item validity.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum Validity {
+    Valid,
+    Reupload,
+    Replace,
+}
+
+impl fmt::Display for Validity {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(self, f)
     }


### PR DESCRIPTION
For mismatched kinds, we keep both nodes with new GUIDs. This is an
edge case: Places maintenance on Desktop can change an item's
kind without changing its GUID, but this should be rare.

In general, we can't meaningfully pick a side when two items have
different kinds (a bookmark and a folder with children? a bookmark and
a separator?), so we keep both, with new structure, to avoid possible
data loss.

See #13.