### PR TITLE
Add an `UploadReason` for merged descendants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,4 +29,4 @@ pub use crate::error::{Error, ErrorKind, Result};
 pub use crate::guid::{Guid, ROOT_GUID, USER_CONTENT_ROOTS};
 pub use crate::merge::{Deletion, Merger, StructureCounts};
 pub use crate::store::{MergeTimings, Stats, Store};
-pub use crate::tree::{Child, Content, Item, Kind, Validity, MergedDescendant, MergeState, MergedNode, ParentGuidFrom, Tree};
+pub use crate::tree::{Child, Content, Item, Kind, Validity, MergedDescendant, MergeState, MergedNode, ParentGuidFrom, Tree, UploadReason};


### PR DESCRIPTION
We'll use this on Desktop to track sync loops, where two or more
clients reupload the same record on every sync, even though the
user hasn't changed it locally.

The idea is: on every sync, we'll store the GUIDs of all uploaded items
in a separate table, along with the timestamp and reason. If we see a
GUID uploaded with `NewStructure` for 5-ish consecutive syncs, we'll
emit telemetry.