### PR TITLE
Re-add the `log` crate for logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,8 @@ exclude = ["/.travis/**", ".travis.yml"]
 edition = "2018"
 
 [dependencies]
+log = "0.4"
 smallbitvec = "2.3.0"
+
+[dev-dependencies]
+env_logger = "0.5.6"

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -51,7 +51,7 @@ pub trait Driver {
     /// Implementations can override this method to return a custom logger,
     /// where using the global logger won't work. For example, Firefox Desktop
     /// has an existing Sync logging setup outside of the `log` crate.
-    fn logger(&self) -> &Log {
+    fn logger(&self) -> &dyn Log {
         log::logger()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ mod tree;
 #[cfg(test)]
 mod tests;
 
-pub use crate::driver::{DefaultDriver, Driver, LogLevel};
+pub use crate::driver::{DefaultDriver, Driver};
 pub use crate::error::{Error, ErrorKind, Result};
 pub use crate::guid::{Guid, MENU_GUID, MOBILE_GUID, ROOT_GUID, TOOLBAR_GUID, UNFILED_GUID};
 pub use crate::merge::{Deletion, Merger, StructureCounts};

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{cell::Cell, collections::HashMap};
+use std::{cell::Cell, collections::HashMap, sync::Once};
+
+use env_logger;
 
 use crate::driver::Driver;
 use crate::error::{ErrorKind, Result};
@@ -87,7 +89,12 @@ macro_rules! nodes {
     }};
 }
 
-fn before_each() {}
+fn before_each() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        env_logger::init();
+    });
+}
 
 #[test]
 fn reparent_and_reposition() {


### PR DESCRIPTION
On Slack, @mhammond suggested using `log::Level` instead of rolling
our own. It turns out that `log` exposes all the building blocks for
logging messages, too, so we can have `Driver` return an implementation
of `log::Log` instead of handling logging ourselves.

The default implementation returns the global logger, so things will
"just work" in Rust Places. On Desktop, we'll have `XpComLogger`
implement `log::Log`, and return that instead of the global one.

See #20.