### PR TITLE
Record and report why the structure diverged for logging and validation

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -375,13 +375,11 @@ impl IntoTree for Builder {
                             }
                         }
                         ResolvedParent::ByParentGuid(parent_index) => {
-                            // We _can_ prefer a parent `by_parent_guid` over a
-                            // parent `by_children` for misparented user content
-                            // roots, but we should never prefer a parent by
-                            // GUID over a parent by children _for the same
-                            // parent_, since the latter loses the child's
-                            // position.
-                            assert_ne!(*parent_index, entry_index);
+                            // We should only ever prefer parents
+                            // `by_parent_guid` over parents `by_children` for
+                            // misparented user content roots. Otherwise,
+                            // there's a bug in `ResolveParent`.
+                            assert_eq!(*parent_index, 0);
                             divergence = Divergence::Diverged;
                         }
                     },


### PR DESCRIPTION
This PR refactors how we resolve diverging structure, and adds a way to report those problems. The diff is pretty big; it's easier to follow the individual commits, which I've tried to break up into reviewable chunks.

The reports are most useful for logging, so we can see why Dogear decided something diverged. Right now, there's no way to tell without examining the DB before a sync, or looking at the server records in About Sync.

We could even turn on debug (trace has PII concerns) and success logging for _just this sync_ if we detect problems. That way, when folks notice issues, they can hopefully upload more complete logs...we wouldn't need to ask them to try to reproduce. We could also explore automated log collection; maybe in Rust Places via Sentry? Though, again, we'd need to make sure there's no PII.

Also, we could use this problem data to report validation errors, like we do on Desktop! It doesn't report non-structure differences...but, since we already have the complete structure, we're already effectively validating before each sync, anyway.

(I think an independent validator in About Sync is still useful—what if Dogear's validator has bugs, or there's a bug in how we fetch or store the tree structure in the DB? Who watches the watcher? 😆 But this might be a better approach for bookmark validation on mobile).

I've also tried to add comments where they make sense, because I don't want Dogear to be write-only. :joy: Let me know if there's anything unclear, or if there are obvious comments that I can remove!