### PR TITLE
Use `Cow<'t, Guid>` for most GUIDs

### DIFF
--- a/src/guid.rs
+++ b/src/guid.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::{
+    borrow::Cow,
     cmp::Ordering,
     fmt,
     hash::{Hash, Hasher},
@@ -221,13 +222,6 @@ impl PartialEq<str> for Guid {
     }
 }
 
-impl<'a> PartialEq<&'a str> for Guid {
-    #[inline]
-    fn eq(&self, other: &&'a str) -> bool {
-        self == *other
-    }
-}
-
 impl PartialEq for Guid {
     #[inline]
     fn eq(&self, other: &Guid) -> bool {
@@ -235,10 +229,29 @@ impl PartialEq for Guid {
     }
 }
 
+impl<'a> PartialEq<&'a Guid> for Guid {
+    #[inline]
+    fn eq(&self, other: &&Guid) -> bool {
+        self == *other
+    }
+}
+
 impl<'a> PartialEq<Guid> for &'a Guid {
     #[inline]
     fn eq(&self, other: &Guid) -> bool {
         *self == other
+    }
+}
+
+impl<'a> From<Guid> for Cow<'a, Guid> {
+    fn from(guid: Guid) -> Cow<'a, Guid> {
+        Cow::Owned(guid)
+    }
+}
+
+impl<'a> From<&'a Guid> for Cow<'a, Guid> {
+    fn from(guid: &'a Guid) -> Cow<'a, Guid> {
+        Cow::Borrowed(guid)
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -76,7 +76,7 @@ macro_rules! nodes {
     ($guid:expr, $kind:ident) => { nodes!(Guid::from($guid), $kind[]) };
     ($guid:expr, $kind:ident [ $( $name:ident = $value:expr ),* ]) => {{
         #[allow(unused_mut)]
-        let mut item = Item::new(Guid::from($guid), Kind::$kind);
+        let mut item = Item::new(Guid::from($guid).into(), Kind::$kind);
         $({ item.$name = $value; })*
         Node::new(item)
     }};


### PR DESCRIPTION
Valid GUIDs are cheap to clone, but we can avoid even that, since a `Merger` (and the merged nodes it returns) can't outlive the trees it's merging.

Mooo! 🐮