### PR TITLE
Enable the `rust_2018_idioms` lint

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -65,7 +65,7 @@ impl Driver for DefaultDriver {}
 pub fn log<D: Driver>(
     driver: &D,
     level: Level,
-    args: Arguments,
+    args: Arguments<'_>,
     module_path: &'static str,
     file: &'static str,
     line: u32,

--- a/src/error.rs
+++ b/src/error.rs
@@ -56,7 +56,7 @@ impl From<Utf8Error> for Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind() {
             ErrorKind::MismatchedItemKind(local_kind, remote_kind) => write!(
                 f,

--- a/src/guid.rs
+++ b/src/guid.rs
@@ -252,13 +252,13 @@ impl Hash for Guid {
 
 // The default Debug impl is pretty unhelpful here.
 impl fmt::Debug for Guid {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Guid({:?})", self.as_str())
     }
 }
 
 impl fmt::Display for Guid {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
+
 #[macro_use]
 mod driver;
 mod error;

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -206,11 +206,11 @@ impl<'t, D: Driver> Merger<'t, D> {
 
     /// Returns an iterator for all accepted local and remote deletions.
     #[inline]
-    pub fn deletions(&self) -> impl Iterator<Item = Deletion> {
+    pub fn deletions(&self) -> impl Iterator<Item = Deletion<'_>> {
         self.local_deletions().chain(self.remote_deletions())
     }
 
-    pub(crate) fn local_deletions(&self) -> impl Iterator<Item = Deletion> {
+    pub(crate) fn local_deletions(&self) -> impl Iterator<Item = Deletion<'_>> {
         self.delete_locally.iter().filter_map(move |guid| {
             if self.delete_remotely.contains(guid) {
                 None
@@ -232,7 +232,7 @@ impl<'t, D: Driver> Merger<'t, D> {
         })
     }
 
-    pub(crate) fn remote_deletions(&self) -> impl Iterator<Item = Deletion> {
+    pub(crate) fn remote_deletions(&self) -> impl Iterator<Item = Deletion<'_>> {
         self.delete_remotely.iter().map(move |guid| {
             let local_level = self
                 .local_tree
@@ -1544,7 +1544,7 @@ impl<'t, D: Driver> Merger<'t, D> {
 
 /// Indicates if the tree in the remote node is syncable. This filters out
 /// livemarks (bug 1477671) and orphaned Places queries (bug 1433182).
-fn remote_node_is_syncable(remote_node: &Node) -> bool {
+fn remote_node_is_syncable(remote_node: &Node<'_>) -> bool {
     if !remote_node.is_syncable() {
         return false;
     }


### PR DESCRIPTION
Why not? 😄