### PR TITLE
Treat livemarks as non-syncable on both sides

### DIFF
--- a/src/guid.rs
+++ b/src/guid.rs
@@ -147,12 +147,9 @@ impl<T: Copy + Into<usize>> IsValidGuid for [T] {
     #[inline]
     fn is_valid_guid(&self) -> bool {
         self.len() == 12
-            && self.iter().all(|&byte| {
-                VALID_GUID_BYTES
-                    .get(byte.into())
-                    .map(|&b| b == 1)
-                    .unwrap_or(false)
-            })
+            && self
+                .iter()
+                .all(|&byte| VALID_GUID_BYTES.get(byte.into()).map_or(false, |&b| b == 1))
     }
 }
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -218,8 +218,7 @@ impl<'t, D: Driver> Merger<'t, D> {
                 let local_level = self
                     .local_tree
                     .node_for_guid(guid)
-                    .map(|node| node.level())
-                    .unwrap_or(-1);
+                    .map_or(-1, |node| node.level());
                 // Items that should be deleted locally already have tombstones
                 // on the server, so we don't need to upload tombstones for
                 // these deletions.
@@ -237,8 +236,7 @@ impl<'t, D: Driver> Merger<'t, D> {
             let local_level = self
                 .local_tree
                 .node_for_guid(guid)
-                .map(|node| node.level())
-                .unwrap_or(-1);
+                .map_or(-1, |node| node.level());
             Deletion {
                 guid,
                 local_level,

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -20,7 +20,7 @@ use std::{
 use crate::driver::{DefaultDriver, Driver};
 use crate::error::{ErrorKind, Result};
 use crate::guid::{Guid, IsValidGuid};
-use crate::tree::{Content, Kind, MergeState, MergedNode, MergedRoot, Node, Tree, Validity};
+use crate::tree::{Content, MergeState, MergedNode, MergedRoot, Node, Tree, Validity};
 
 /// Structure change types, used to indicate if a node on one side is moved
 /// or deleted on the other.
@@ -1006,7 +1006,7 @@ impl<'t, D: Driver> Merger<'t, D> {
         remote_parent_node: Node<'t>,
         remote_node: Node<'t>,
     ) -> Result<StructureChange> {
-        if !remote_node_is_syncable(&remote_node) {
+        if !remote_node.is_syncable() {
             // If the remote node is known to be non-syncable, we unconditionally
             // delete it, even if it's syncable or moved locally.
             return self.delete_remote_node(merged_node, remote_node);
@@ -1110,7 +1110,7 @@ impl<'t, D: Driver> Merger<'t, D> {
 
         if !self.remote_tree.is_deleted(&local_node.guid) {
             if let Some(remote_node) = self.remote_tree.node_for_guid(&local_node.guid) {
-                if !remote_node_is_syncable(&remote_node) {
+                if !remote_node.is_syncable() {
                     // The local node is syncable, but the remote node is not.
                     // This can happen if we applied an orphaned left pane
                     // query in a previous sync, and later saw the left pane
@@ -1539,18 +1539,5 @@ impl<'t, D: Driver> Merger<'t, D> {
             );
             None
         }
-    }
-}
-
-/// Indicates if the tree in the remote node is syncable. This filters out
-/// livemarks (bug 1477671) and orphaned Places queries (bug 1433182).
-fn remote_node_is_syncable(remote_node: &Node<'_>) -> bool {
-    if !remote_node.is_syncable() {
-        return false;
-    }
-    match remote_node.kind {
-        Kind::Livemark => false,
-        Kind::Query if remote_node.diverged() => false,
-        _ => true,
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2633,7 +2633,7 @@ fn cycle() {
         .kind()
     {
         ErrorKind::Cycle(guid) => assert_eq!(guid, &Guid::from("folderAAAAAA")),
-        err => assert!(false, "Wrong error kind for cycle: {:?}", err),
+        err => panic!("Wrong error kind for cycle: {:?}", err),
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1751,6 +1751,72 @@ fn left_pane_root() {
 }
 
 #[test]
+fn livemarks() {
+    before_each();
+
+    let local_tree = nodes!({
+        ("menu________", Folder, {
+            ("livemarkAAAA", Livemark),
+            ("livemarkBBBB", Folder),
+            ("livemarkCCCC", Livemark)
+        }),
+        ("toolbar_____", Folder, {
+            ("livemarkDDDD", Livemark)
+        })
+    })
+    .into_tree()
+    .unwrap();
+
+    let remote_tree = nodes!({
+        ("menu________", Folder, {
+            ("livemarkAAAA", Livemark),
+            ("livemarkBBBB", Livemark),
+            ("livemarkCCCC", Folder)
+        }),
+        ("unfiled_____", Folder, {
+            ("livemarkEEEE", Livemark)
+        })
+    })
+    .into_tree()
+    .unwrap();
+
+    let mut merger = Merger::new(&local_tree, &remote_tree);
+    let merged_root = merger.merge().unwrap();
+    assert!(merger.subsumes(&local_tree));
+    assert!(merger.subsumes(&remote_tree));
+
+    let expected_tree = nodes!({
+        ("menu________", Folder[needs_merge = true]),
+        ("toolbar_____", Folder[needs_merge = true]),
+        ("unfiled_____", Folder[needs_merge = true])
+    })
+    .into_tree()
+    .unwrap();
+    let expected_deletions = vec![
+        "livemarkAAAA",
+        "livemarkBBBB",
+        "livemarkCCCC",
+        "livemarkDDDD",
+        "livemarkEEEE",
+    ];
+    let expected_telem = StructureCounts {
+        merged_nodes: 3,
+        // A, B, and C are counted twice, since they exist on both sides.
+        merged_deletions: 8,
+        ..StructureCounts::default()
+    };
+
+    let merged_tree = merged_root.into_tree().unwrap();
+    assert_eq!(merged_tree, expected_tree);
+
+    let mut deletions = merger.deletions().map(|d| d.guid).collect::<Vec<_>>();
+    deletions.sort();
+    assert_eq!(deletions, expected_deletions);
+
+    assert_eq!(merger.counts(), &expected_telem);
+}
+
+#[test]
 fn non_syncable_items() {
     before_each();
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1221,13 +1221,16 @@ impl<'t> Node<'t> {
         if self.is_user_content_root() {
             return true;
         }
-        if self.kind == Kind::Query && self.diverged() {
-            // TODO(lina): Flag queries reparented specifically to `unfiled`.
-            return false;
+        match self.kind {
+            // Exclude livemarks (bug 1477671).
+            Kind::Livemark => false,
+            // Exclude orphaned Places queries (bug 1433182).
+            Kind::Query if self.diverged() => false,
+            _ => self
+                .parent()
+                .map(|parent| parent.is_syncable())
+                .unwrap_or(false),
         }
-        self.parent()
-            .map(|parent| parent.is_syncable())
-            .unwrap_or(false)
     }
 
     /// Indicates if this node's structure diverged because it

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -802,7 +802,10 @@ impl<'a> ResolveParent<'a> {
                 self.problems.note(
                     &self.entry.item.guid,
                     Problem::DivergedParents(
-                        possible_parents.iter().map(|p| p.summarize()).collect(),
+                        possible_parents
+                            .iter()
+                            .map(PossibleParent::summarize)
+                            .collect(),
                     ),
                 );
                 possible_parents

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1197,7 +1197,7 @@ impl<'t> Node<'t> {
         if self.is_root() {
             return 0;
         }
-        self.parent().map(|parent| parent.level() + 1).unwrap_or(-1)
+        self.parent().map_or(-1, |parent| parent.level() + 1)
     }
 
     /// Indicates if this node is for a syncable item.
@@ -1226,10 +1226,7 @@ impl<'t> Node<'t> {
             Kind::Livemark => false,
             // Exclude orphaned Places queries (bug 1433182).
             Kind::Query if self.diverged() => false,
-            _ => self
-                .parent()
-                .map(|parent| parent.is_syncable())
-                .unwrap_or(false),
+            _ => self.parent().map_or(false, |parent| parent.is_syncable()),
         }
     }
 
@@ -1529,8 +1526,7 @@ impl<'t> MergedNode<'t> {
     pub(crate) fn remote_guid_changed(&self) -> bool {
         self.merge_state
             .remote_node()
-            .map(|remote_node| remote_node.guid != self.guid)
-            .unwrap_or(false)
+            .map_or(false, |remote_node| remote_node.guid != self.guid)
     }
 
     fn to_ascii_fragment(&self, prefix: &str) -> String {


### PR DESCRIPTION
Livemarks are no longer supported in Firefox, so let's delete them
from the tree entirely, on both sides. The bookmarks engine on Desktop
can export existing livemarks before a first sync, to avoid data loss.