### PR TITLE
Use Box<str> for Guid

### DIFF
--- a/src/guid.rs
+++ b/src/guid.rs
@@ -214,7 +214,7 @@ impl PartialOrd for Guid {
 impl PartialEq<str> for Guid {
     #[inline]
     fn eq(&self, other: &str) -> bool {
-        self.as_str() == other
+        self.as_bytes() == other.as_bytes()
     }
 }
 

--- a/src/guid.rs
+++ b/src/guid.rs
@@ -37,7 +37,7 @@ pub trait IsValidGuid {
 #[derive(Clone)]
 enum Repr {
     Valid([u8; 12]),
-    Invalid(String),
+    Invalid(Box<str>),
 }
 
 /// The Places root GUID, used to root all items in a bookmark tree.
@@ -95,7 +95,7 @@ impl Guid {
             Repr::Valid(bytes)
         } else {
             match String::from_utf16(b) {
-                Ok(s) => Repr::Invalid(s),
+                Ok(s) => Repr::Invalid(s.into()),
                 Err(err) => return Err(err.into()),
             }
         };
@@ -107,7 +107,7 @@ impl Guid {
     pub fn as_bytes(&self) -> &[u8] {
         match self.0 {
             Repr::Valid(ref bytes) => bytes,
-            Repr::Invalid(ref s) => s.as_ref(),
+            Repr::Invalid(ref s) => s.as_bytes(),
         }
     }
 


### PR DESCRIPTION
While I was here, figured I'd do this. I also noticed we're doing a bit more work than we have to when comparing Guids.

From `dbg!(std::mem::size_of::<Guid>())`

Before: `[src/guid.rs:269] std::mem::size_of::<Guid>() = 32`
After: `[src/guid.rs:269] std::mem::size_of::<Guid>() = 24`

Probably doesn't matter on 32 bit targets, but I haven't checked because it's more annoying to do so.