### PR TITLE
Add `Problems::counts()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,6 @@ pub use crate::guid::{Guid, MENU_GUID, MOBILE_GUID, ROOT_GUID, TOOLBAR_GUID, UNF
 pub use crate::merge::{Deletion, Merger, StructureCounts};
 pub use crate::store::{MergeTimings, Stats, Store};
 pub use crate::tree::{
-    Content, Item, Kind, MergeState, MergedDescendant, MergedNode, MergedRoot, Tree, UploadReason,
-    Validity,
+    Content, Item, Kind, MergeState, MergedDescendant, MergedNode, MergedRoot, ProblemCounts, Tree,
+    UploadReason, Validity,
 };

--- a/src/store.rs
+++ b/src/store.rs
@@ -18,13 +18,14 @@ use crate::driver::{AbortSignal, DefaultAbortSignal, DefaultDriver, Driver};
 use crate::error::{Error, ErrorKind};
 use crate::guid::Guid;
 use crate::merge::{Deletion, Merger, StructureCounts};
-use crate::tree::{Content, MergedRoot, Tree};
+use crate::tree::{Content, MergedRoot, ProblemCounts, Tree};
 
 /// Records timings and counters for telemetry.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Stats {
     pub timings: MergeTimings,
     pub counts: StructureCounts,
+    pub problems: ProblemCounts,
 }
 
 /// Records timings for merging operations.
@@ -162,6 +163,10 @@ pub trait Store<E: From<Error>> {
         Ok(Stats {
             timings: merge_timings,
             counts: *merger.counts(),
+            problems: local_tree
+                .problems()
+                .counts()
+                .add(remote_tree.problems().counts()),
         })
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -26,8 +26,8 @@ use crate::error::{Error, ErrorKind, Result};
 use crate::guid::{Guid, ROOT_GUID, UNFILED_GUID};
 use crate::merge::{Merger, StructureCounts};
 use crate::tree::{
-    Builder, Content, DivergedParent, DivergedParentGuid, Item, Kind, Problem, Problems, Tree,
-    Validity,
+    Builder, Content, DivergedParent, DivergedParentGuid, Item, Kind, Problem, ProblemCounts,
+    Problems, Tree, Validity,
 };
 
 #[derive(Debug)]
@@ -2803,7 +2803,19 @@ fn problems() {
                 DivergedParentGuid::Missing("folderKKKKKK".into()).into(),
             ]),
         )
-        .note(&"bookmarkLLLL".into(), Problem::DivergedParents(Vec::new()));
+        .note(&"bookmarkLLLL".into(), Problem::DivergedParents(Vec::new()))
+        .note(
+            &"folderMMMMMM".into(),
+            Problem::MissingChild {
+                child_guid: "bookmarkNNNN".into(),
+            },
+        )
+        .note(
+            &"folderMMMMMM".into(),
+            Problem::MissingChild {
+                child_guid: "bookmarkOOOO".into(),
+            },
+        );
 
     let mut summary = problems.summarize().collect::<Vec<_>>();
     summary.sort_by(|a, b| a.guid().cmp(b.guid()));
@@ -2819,8 +2831,23 @@ fn problems() {
             "bookmarkHHHH is in children of folderIIIIII, is in children of folderJJJJJJ, and has \
              nonexistent parent folderKKKKKK",
             "bookmarkLLLL has diverged parents",
+            "folderMMMMMM has nonexistent child bookmarkNNNN",
+            "folderMMMMMM has nonexistent child bookmarkOOOO",
             "menu________ is a user content root, but is in children of unfiled_____",
             "toolbar_____ is a user content root",
         ]
+    );
+
+    assert_eq!(
+        problems.counts(),
+        ProblemCounts {
+            orphans: 1,
+            misparented_roots: 2,
+            multiple_parents_by_children: 3,
+            missing_parent_guids: 1,
+            non_folder_parent_guids: 1,
+            parent_child_disagreements: 6,
+            missing_children: 2,
+        }
     );
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1040,6 +1040,88 @@ pub enum Problem {
     MissingChild { child_guid: Guid },
 }
 
+impl Problem {
+    /// Returns count deltas for this problem.
+    fn counts(&self) -> ProblemCounts {
+        let (parents, deltas) = match self {
+            Problem::Orphan => {
+                return ProblemCounts {
+                    orphans: 1,
+                    ..ProblemCounts::default()
+                }
+            }
+            Problem::MissingChild { .. } => {
+                return ProblemCounts {
+                    missing_children: 1,
+                    ..ProblemCounts::default()
+                }
+            }
+            // For misparented roots, or items with diverged parents, we need to
+            // do a bit more work to determine all the problems. For example, a
+            // toolbar root with a `parentid` pointing to a nonexistent folder,
+            // and mentioned in the `children` of unfiled and menu has three
+            // problems: it's a misparented root, with multiple parents, and a
+            // missing `parentid`.
+            Problem::MisparentedRoot(parents) => (
+                parents,
+                ProblemCounts {
+                    misparented_roots: 1,
+                    ..ProblemCounts::default()
+                },
+            ),
+            Problem::DivergedParents(parents) => (parents, ProblemCounts::default()),
+        };
+        let deltas = match parents.as_slice() {
+            // For items with different parents `by_parent_guid` and
+            // `by_children`, report a parent-child disagreement.
+            [DivergedParent::ByChildren(_)]
+            | [DivergedParent::ByParentGuid(_)]
+            | [DivergedParent::ByChildren(_), DivergedParent::ByParentGuid(_)]
+            | [DivergedParent::ByParentGuid(_), DivergedParent::ByChildren(_)] => ProblemCounts {
+                parent_child_disagreements: 1,
+                ..deltas
+            },
+            // For items with multiple parents `by_children`, and possibly by
+            // `by_parent_guid`, report a disagreement _and_ multiple parents.
+            _ => ProblemCounts {
+                multiple_parents_by_children: 1,
+                parent_child_disagreements: 1,
+                ..deltas
+            },
+        };
+        // Count invalid or missing parents, but only once, since we're counting
+        // the number of _items with the problem_, not the _occurrences of the
+        // problem_. This is specifically for roots; it doesn't make sense for
+        // other items to have multiple `parentid`s.
+        parents.iter().fold(deltas, |deltas, parent| match parent {
+            DivergedParent::ByChildren(_) => deltas,
+            DivergedParent::ByParentGuid(p) => match p {
+                DivergedParentGuid::Folder(_) => deltas,
+                DivergedParentGuid::NonFolder(_) => {
+                    if deltas.non_folder_parent_guids > 0 {
+                        deltas
+                    } else {
+                        ProblemCounts {
+                            non_folder_parent_guids: 1,
+                            ..deltas
+                        }
+                    }
+                }
+                DivergedParentGuid::Missing(_) => {
+                    if deltas.missing_parent_guids > 0 {
+                        deltas
+                    } else {
+                        ProblemCounts {
+                            missing_parent_guids: 1,
+                            ..deltas
+                        }
+                    }
+                }
+            },
+        })
+    }
+}
+
 /// Describes where an invalid parent comes from.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum DivergedParent {
@@ -1091,12 +1173,14 @@ pub struct Problems(HashMap<Guid, Vec<Problem>>);
 
 impl Problems {
     /// Notes a problem for an item.
+    #[inline]
     pub fn note(&mut self, guid: &Guid, problem: Problem) -> &mut Problems {
         self.0.entry(guid.clone()).or_default().push(problem);
         self
     }
 
     /// Returns `true` if there are no problems.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
@@ -1108,6 +1192,17 @@ impl Problems {
                 .iter()
                 .map(move |problem| ProblemSummary(guid, problem))
         })
+    }
+
+    /// Returns total counts for each problem. If any counts are not 0, the
+    /// tree structure diverged.
+    pub fn counts(&self) -> ProblemCounts {
+        self.0
+            .values()
+            .flatten()
+            .fold(ProblemCounts::default(), |totals, problem| {
+                totals.add(problem.counts())
+            })
     }
 }
 
@@ -1166,6 +1261,46 @@ impl<'a> fmt::Display for ProblemSummary<'a> {
             }
         }
         Ok(())
+    }
+}
+
+/// Records total problem counts for telemetry. An item can have multiple
+/// problems, but each problem is only counted once per item.
+#[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
+pub struct ProblemCounts {
+    /// Number of items that aren't mentioned in any parent's `children` and
+    /// don't have a `parentid`. These are very rare; it's likely that a
+    /// problem child has at least a `parentid`.
+    pub orphans: usize,
+    /// Number of roots that aren't children of the Places root.
+    pub misparented_roots: usize,
+    /// Number of items with multiple, conflicting parents `by_children`.
+    pub multiple_parents_by_children: usize,
+    /// Number of items whose `parentid` doesn't exist.
+    pub missing_parent_guids: usize,
+    /// Number of items whose `parentid` isn't a folder.
+    pub non_folder_parent_guids: usize,
+    /// Number of items whose `parentid`s disagree with their parents'
+    /// `children`.
+    pub parent_child_disagreements: usize,
+    /// Number of nonexistent items mentioned in all parents' `children`.
+    pub missing_children: usize,
+}
+
+impl ProblemCounts {
+    /// Adds two sets of counts together.
+    pub fn add(&self, other: ProblemCounts) -> ProblemCounts {
+        ProblemCounts {
+            orphans: self.orphans + other.orphans,
+            misparented_roots: self.misparented_roots + other.misparented_roots,
+            multiple_parents_by_children: self.multiple_parents_by_children
+                + other.multiple_parents_by_children,
+            missing_parent_guids: self.missing_parent_guids + other.missing_parent_guids,
+            non_folder_parent_guids: self.non_folder_parent_guids + other.non_folder_parent_guids,
+            parent_child_disagreements: self.parent_child_disagreements
+                + other.parent_child_disagreements,
+            missing_children: self.missing_children + other.missing_children,
+        }
     }
 }
 


### PR DESCRIPTION
This is similar to `getSummary` on Desktop: it returns the total count for each problem, and we can use the counts to report problems via telemetry.