### PR TITLE
Emit telemetry events after each operation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,11 +27,14 @@ mod tree;
 #[cfg(test)]
 mod tests;
 
-pub use crate::driver::{AbortSignal, DefaultAbortSignal, DefaultDriver, Driver};
+pub use crate::driver::{
+    AbortSignal, ContentsStats, DefaultAbortSignal, DefaultDriver, Driver, TelemetryEvent,
+    TreeStats,
+};
 pub use crate::error::{Error, ErrorKind, Result};
 pub use crate::guid::{Guid, MENU_GUID, MOBILE_GUID, ROOT_GUID, TOOLBAR_GUID, UNFILED_GUID};
 pub use crate::merge::{Deletion, Merger, StructureCounts};
-pub use crate::store::{MergeTimings, Stats, Store};
+pub use crate::store::Store;
 pub use crate::tree::{
     Content, Item, Kind, MergeState, MergedDescendant, MergedNode, MergedRoot, ProblemCounts, Tree,
     UploadReason, Validity,

--- a/src/store.rs
+++ b/src/store.rs
@@ -12,41 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, time::Duration, time::Instant};
 
-use crate::driver::{AbortSignal, DefaultAbortSignal, DefaultDriver, Driver};
+use crate::driver::{
+    AbortSignal, ContentsStats, DefaultAbortSignal, DefaultDriver, Driver, TelemetryEvent,
+    TreeStats,
+};
 use crate::error::{Error, ErrorKind};
 use crate::guid::Guid;
-use crate::merge::{Deletion, Merger, StructureCounts};
-use crate::tree::{Content, MergedRoot, ProblemCounts, Tree};
-
-/// Records timings and counters for telemetry.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct Stats {
-    pub timings: MergeTimings,
-    pub counts: StructureCounts,
-    pub problems: ProblemCounts,
-}
-
-/// Records timings for merging operations.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct MergeTimings {
-    pub fetch_local_tree: Duration,
-    pub fetch_new_local_contents: Duration,
-    pub fetch_remote_tree: Duration,
-    pub fetch_new_remote_contents: Duration,
-    pub merge: Duration,
-    pub apply: Duration,
-}
-
-macro_rules! time {
-    ($timings:ident, $name:ident, $op:expr) => {{
-        let now = std::time::Instant::now();
-        let result = $op;
-        $timings.$name = now.elapsed();
-        result
-    }};
-}
+use crate::merge::{Deletion, Merger};
+use crate::tree::{Content, MergedRoot, Tree};
 
 /// A store is the main interface to Dogear. It implements methods for building
 /// local and remote trees from a storage backend, fetching content info for
@@ -81,39 +56,49 @@ pub trait Store<E: From<Error>> {
     ) -> Result<(), E>;
 
     /// Builds and applies a merged tree using the default merge driver.
-    fn merge(&mut self) -> Result<Stats, E> {
+    fn merge(&mut self) -> Result<(), E> {
         self.merge_with_driver(&DefaultDriver, &DefaultAbortSignal)
     }
 
     /// Builds a complete merged tree from the local and remote trees, resolves
     /// conflicts, dedupes local items, and applies the merged tree using the
     /// given driver.
-    fn merge_with_driver<D: Driver, A: AbortSignal>(
+    fn merge_with_driver(
         &mut self,
-        driver: &D,
-        signal: &A,
-    ) -> Result<Stats, E> {
-        let mut merge_timings = MergeTimings::default();
-
+        driver: &impl Driver,
+        signal: &impl AbortSignal,
+    ) -> Result<(), E> {
         signal.err_if_aborted()?;
-        let local_tree = time!(merge_timings, fetch_local_tree, { self.fetch_local_tree() })?;
+        let (local_tree, time) = with_timing(|| self.fetch_local_tree())?;
+        driver.record_telemetry_event(TelemetryEvent::FetchLocalTree(TreeStats {
+            items: local_tree.size(),
+            problems: local_tree.problems().counts(),
+            time,
+        }));
         debug!(driver, "Built local tree from mirror\n{}", local_tree);
 
         signal.err_if_aborted()?;
-        let new_local_contents = time!(merge_timings, fetch_new_local_contents, {
-            self.fetch_new_local_contents()
-        })?;
+        let (new_local_contents, time) = with_timing(|| self.fetch_new_local_contents())?;
+        driver.record_telemetry_event(TelemetryEvent::FetchNewLocalContents(ContentsStats {
+            items: new_local_contents.len(),
+            time,
+        }));
 
         signal.err_if_aborted()?;
-        let remote_tree = time!(merge_timings, fetch_remote_tree, {
-            self.fetch_remote_tree()
-        })?;
+        let (remote_tree, time) = with_timing(|| self.fetch_remote_tree())?;
+        driver.record_telemetry_event(TelemetryEvent::FetchRemoteTree(TreeStats {
+            items: remote_tree.size(),
+            problems: remote_tree.problems().counts(),
+            time,
+        }));
         debug!(driver, "Built remote tree from mirror\n{}", remote_tree);
 
         signal.err_if_aborted()?;
-        let new_remote_contents = time!(merge_timings, fetch_new_remote_contents, {
-            self.fetch_new_remote_contents()
-        })?;
+        let (new_remote_contents, time) = with_timing(|| self.fetch_new_remote_contents())?;
+        driver.record_telemetry_event(TelemetryEvent::FetchNewRemoteContents(ContentsStats {
+            items: new_local_contents.len(),
+            time,
+        }));
 
         let mut merger = Merger::with_driver(
             driver,
@@ -123,7 +108,8 @@ pub trait Store<E: From<Error>> {
             &remote_tree,
             &new_remote_contents,
         );
-        let merged_root = time!(merge_timings, merge, merger.merge())?;
+        let (merged_root, time) = with_timing(|| merger.merge())?;
+        driver.record_telemetry_event(TelemetryEvent::Merge(time, *merger.counts()));
         debug!(
             driver,
             "Built new merged tree\n{}\nDelete Locally: [{}]\nDelete Remotely: [{}]",
@@ -154,19 +140,14 @@ pub trait Store<E: From<Error>> {
             Err(E::from(ErrorKind::UnmergedRemoteItems.into()))?;
         }
 
-        time!(
-            merge_timings,
-            apply,
-            self.apply(merged_root, merger.deletions())
-        )?;
+        let ((), time) = with_timing(|| self.apply(merged_root, merger.deletions()))?;
+        driver.record_telemetry_event(TelemetryEvent::Apply(time));
 
-        Ok(Stats {
-            timings: merge_timings,
-            counts: *merger.counts(),
-            problems: local_tree
-                .problems()
-                .counts()
-                .add(remote_tree.problems().counts()),
-        })
+        Ok(())
     }
+}
+
+fn with_timing<T, E>(run: impl FnOnce() -> Result<T, E>) -> Result<(T, Duration), E> {
+    let now = Instant::now();
+    run().map(|value| (value, now.elapsed()))
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -62,6 +62,12 @@ impl Tree {
         }
     }
 
+    /// Returns the number of nodes in the tree.
+    #[inline]
+    pub fn size(&self) -> usize {
+        self.entries.len()
+    }
+
     /// Returns the root node.
     #[inline]
     pub fn root(&self) -> Node<'_> {


### PR DESCRIPTION
This commit adds a `Driver::record_telemetry_event` method that's
called with timings and counts after each store operation, instead
of returning a `Stats` struct at the end. This lets consumers like
Desktop record telemetry for interrupted or failed merges, and track
progress so we can see why some merges cause shutdown hangs.

https://bugzilla.mozilla.org/show_bug.cgi?id=1552621 has more details.