### PR TITLE
 Improve handling for unchanged and locally changed items

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,15 +27,9 @@ mod tree;
 #[cfg(test)]
 mod tests;
 
-pub use crate::driver::{
-    AbortSignal, ContentsStats, DefaultAbortSignal, DefaultDriver, Driver, TelemetryEvent,
-    TreeStats,
-};
-pub use crate::error::{Error, ErrorKind, Result};
-pub use crate::guid::{Guid, MENU_GUID, MOBILE_GUID, ROOT_GUID, TOOLBAR_GUID, UNFILED_GUID};
-pub use crate::merge::{Deletion, Merger, StructureCounts};
-pub use crate::store::Store;
-pub use crate::tree::{
-    Content, Item, Kind, MergeState, MergedDescendant, MergedNode, MergedRoot, ProblemCounts, Tree,
-    UploadReason, Validity,
-};
+pub use crate::driver::*;
+pub use crate::error::*;
+pub use crate::guid::*;
+pub use crate::merge::*;
+pub use crate::store::*;
+pub use crate::tree::*;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1109,9 +1109,9 @@ fn nonexistent_on_one_side() {
     assert!(merger.subsumes(&local_tree));
     assert!(merger.subsumes(&remote_tree));
 
-    let mut expected_root = Item::new(ROOT_GUID, Kind::Folder);
-    expected_root.needs_merge = true;
-    let expected_tree = Tree::with_root(expected_root).into_tree().unwrap();
+    let expected_tree = Tree::with_root(Item::new(ROOT_GUID, Kind::Folder))
+        .into_tree()
+        .unwrap();
     let expected_deletions = vec!["bookmarkAAAA", "bookmarkBBBB"];
     let expected_telem = StructureCounts {
         merged_deletions: 2,
@@ -1961,7 +1961,7 @@ fn applying_two_empty_folders_doesnt_smush() {
     assert!(merger.subsumes(&local_tree));
     assert!(merger.subsumes(&remote_tree));
 
-    let expected_tree = nodes!({
+    let expected_tree = nodes!(ROOT_GUID, Folder, {
         ("mobile______", Folder, {
             ("emptyempty01", Folder),
             ("emptyempty02", Folder)
@@ -2370,7 +2370,7 @@ fn multiple_parents() {
     assert!(merger.subsumes(&local_tree));
     assert!(merger.subsumes(&remote_tree));
 
-    let expected_tree = nodes!({
+    let expected_tree = nodes!(ROOT_GUID, Folder, {
         ("toolbar_____", Folder[age = 5, needs_merge = true], {
             ("bookmarkBBBB", Bookmark)
         }),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2837,7 +2837,7 @@ fn completion_ops() {
     let ops = merged_root.completion_ops();
     assert!(ops.change_guids.is_empty());
     assert_eq!(
-        ops.apply_remote
+        ops.apply_remote_items
             .iter()
             .map(|op| op.to_string())
             .collect::<Vec<String>>(),
@@ -2861,8 +2861,9 @@ fn completion_ops() {
             "Move bookmarkHHHH into unfiled_____ at 0",
         ]
     );
+    assert!(ops.upload.is_empty());
     assert_eq!(
-        ops.update_sync_change_counters
+        ops.skip_upload
             .iter()
             .map(|op| op.to_string())
             .collect::<Vec<String>>(),


### PR DESCRIPTION
This PR overhauls how the merger records and applies local changes.
Before, new structure was only used to flag merged items for
reupload. Consumers would apply the merged tree by storing all merge
states in an SQLite temp table, then firing triggers that examined and
updated every item. This was inefficient, and the process could take
several seconds for a large tree on Desktop.

To improve this, we introduce two concepts: new local structure, and
completion operations.

New local structure is the analog to new remote structure, and is set
for all items with newer local changes that are reparented or
repositioned in the merged tree. (Remote-only items, and items with
newer remote changes, have new local structure by definition). The
merger now flags relocated orphans, deleted non-syncable and invalid
items, items with deduped and changed GUIDs, reparented items, and
folders with moved children, as having new local structure.

Merging now produces a sequence of completion operations, instead of
raw merged descendants. Completion ops describe how to update the local
tree so that it matches the remote tree. These include changing GUIDs,
taking remote items, applying new structure, and updating change
counters. We try to avoid emitting completion ops for items that didn't
change (like children of a folder with new local structure that have
the same positions) to avoid unnecessary database work. The name
"completion ops" comes from Firefox for iOS, which had a similar
concept in its old bookmark sync implementation.

Additionally, the "unchanged" merge state really means unchanged now.
Before, it meant something like "unchanged, possibly with new
children". "Unchanged with new local structure" is a new state that's
used for roots, where we want to apply merged children, but not a
synced root's title. We compare child GUIDs to determine if a folder's
local and remote children are unchanged, and use a new
`merge_unchanged_child_into_merged_node` method that skips checking for
moved children.

Finally, we now check validity when determining which side to take, and
pick the valid side even if it's unchanged or older.

Closes #46.