### PR TITLE
Emit completion ops for tombstones

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -68,6 +68,7 @@ pub enum TelemetryEvent {
 pub struct TreeStats {
     pub time: Duration,
     pub items: usize,
+    pub deletions: usize,
     pub problems: ProblemCounts,
 }
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1945,21 +1945,17 @@ impl<'t> CompletionOps<'t> {
     /// Returns a printable summary of all completion ops to apply.
     pub fn summarize(&self) -> Vec<String> {
         std::iter::empty()
-            .chain(self.change_guids.iter().map(ToString::to_string))
-            .chain(self.apply_remote_items.iter().map(ToString::to_string))
-            .chain(
-                self.apply_new_local_structure
-                    .iter()
-                    .map(ToString::to_string),
-            )
-            .chain(self.set_local_unmerged.iter().map(ToString::to_string))
-            .chain(self.set_local_merged.iter().map(ToString::to_string))
-            .chain(self.set_remote_merged.iter().map(ToString::to_string))
-            .chain(self.delete_local_tombstones.iter().map(ToString::to_string))
-            .chain(self.insert_local_tombstones.iter().map(ToString::to_string))
-            .chain(self.delete_local_items.iter().map(ToString::to_string))
-            .chain(self.upload_items.iter().map(ToString::to_string))
-            .chain(self.upload_tombstones.iter().map(ToString::to_string))
+            .chain(to_strings(&self.change_guids))
+            .chain(to_strings(&self.apply_remote_items))
+            .chain(to_strings(&self.apply_new_local_structure))
+            .chain(to_strings(&self.set_local_unmerged))
+            .chain(to_strings(&self.set_local_merged))
+            .chain(to_strings(&self.set_remote_merged))
+            .chain(to_strings(&self.delete_local_tombstones))
+            .chain(to_strings(&self.insert_local_tombstones))
+            .chain(to_strings(&self.delete_local_items))
+            .chain(to_strings(&self.upload_items))
+            .chain(to_strings(&self.upload_tombstones))
             .collect()
     }
 }
@@ -2278,4 +2274,9 @@ fn accumulate<'t, A: AbortSignal>(
         accumulate(signal, ops, merged_child_node, level + 1, is_tagging)?;
     }
     Ok(())
+}
+
+/// Converts all items in the list to strings.
+pub(crate) fn to_strings<'a, T: ToString>(items: &'a [T]) -> impl Iterator<Item = String> + 'a {
+    items.iter().map(ToString::to_string)
 }

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -2063,7 +2063,7 @@ pub struct SetLocalUnmerged<'t> {
 
 impl<'t> fmt::Display for SetLocalUnmerged<'t> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Flag {} for upload", self.merged_node.guid)
+        write!(f, "Flag local {} as unmerged", self.merged_node.guid)
     }
 }
 
@@ -2076,7 +2076,7 @@ pub struct SetLocalMerged<'t> {
 
 impl<'t> fmt::Display for SetLocalMerged<'t> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Don't upload {}", self.merged_node.guid)
+        write!(f, "Flag local {} as merged", self.merged_node.guid)
     }
 }
 
@@ -2124,7 +2124,7 @@ impl<'t> SetRemoteMerged<'t> {
 
 impl<'t> fmt::Display for SetRemoteMerged<'t> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Flag {} as merged", self.guid())
+        write!(f, "Flag remote {} as merged", self.guid())
     }
 }
 
@@ -2142,7 +2142,7 @@ impl<'t> InsertLocalTombstone<'t> {
 
 impl<'t> fmt::Display for InsertLocalTombstone<'t> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Upload tombstone for {}", self.0.guid)
+        write!(f, "Insert local tombstone {}", self.0.guid)
     }
 }
 
@@ -2160,7 +2160,7 @@ impl<'t> DeleteLocalTombstone<'t> {
 
 impl<'t> fmt::Display for DeleteLocalTombstone<'t> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Remove tombstone for {}", self.0)
+        write!(f, "Delete local tombstone {}", self.0)
     }
 }
 
@@ -2178,7 +2178,7 @@ impl<'t> DeleteLocalItem<'t> {
 
 impl<'t> fmt::Display for DeleteLocalItem<'t> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Delete {} from local tree", self.0.guid)
+        write!(f, "Delete local item {}", self.0.guid)
     }
 }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -63,6 +63,7 @@ pub trait Store {
         let (local_tree, time) = with_timing(|| self.fetch_local_tree())?;
         driver.record_telemetry_event(TelemetryEvent::FetchLocalTree(TreeStats {
             items: local_tree.size(),
+            deletions: local_tree.deletions().len(),
             problems: local_tree.problems().counts(),
             time,
         }));
@@ -73,6 +74,7 @@ pub trait Store {
         let (remote_tree, time) = with_timing(|| self.fetch_remote_tree())?;
         driver.record_telemetry_event(TelemetryEvent::FetchRemoteTree(TreeStats {
             items: remote_tree.size(),
+            deletions: local_tree.deletions().len(),
             problems: remote_tree.problems().counts(),
             time,
         }));

--- a/src/store.rs
+++ b/src/store.rs
@@ -18,6 +18,7 @@ use crate::driver::{
     AbortSignal, DefaultAbortSignal, DefaultDriver, Driver, TelemetryEvent, TreeStats,
 };
 use crate::error::Error;
+use crate::guid::Guid;
 use crate::merge::{MergedRoot, Merger};
 use crate::tree::Tree;
 
@@ -91,12 +92,12 @@ pub trait Store {
             merged_root.node().to_ascii_string(),
             merged_root
                 .local_deletions()
-                .map(|guid| guid.as_str())
+                .map(Guid::as_str)
                 .collect::<Vec<_>>()
                 .join(", "),
             merged_root
                 .remote_deletions()
-                .map(|guid| guid.as_str())
+                .map(Guid::as_str)
                 .collect::<Vec<_>>()
                 .join(", ")
         );

--- a/src/store.rs
+++ b/src/store.rs
@@ -89,12 +89,12 @@ pub trait Store {
             merged_root.node().to_ascii_string(),
             merged_root
                 .local_deletions()
-                .map(|d| d.guid.as_str())
+                .map(|guid| guid.as_str())
                 .collect::<Vec<_>>()
                 .join(", "),
             merged_root
                 .remote_deletions()
-                .map(|d| d.guid.as_str())
+                .map(|guid| guid.as_str())
                 .collect::<Vec<_>>()
                 .join(", ")
         );

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -476,7 +476,7 @@ fn unchanged_newer_changed_older() {
             ("bookmarkFFFF", RemoteWithNewRemoteStructure)
         })
     });
-    let expected_deletions = vec!["folderAAAAAA", "folderCCCCCC"];
+    let expected_deletions = &["folderAAAAAA", "folderCCCCCC"];
     let expected_telem = StructureCounts {
         local_deletes: 1,
         remote_deletes: 1,
@@ -924,7 +924,7 @@ fn complex_orphaning() {
             })
         })
     });
-    let expected_deletions = vec!["folderBBBBBB", "folderEEEEEE"];
+    let expected_deletions = &["folderBBBBBB", "folderEEEEEE"];
     let expected_telem = StructureCounts {
         local_deletes: 1,
         remote_deletes: 1,
@@ -1015,7 +1015,7 @@ fn locally_modified_remotely_deleted() {
             })
         })
     });
-    let expected_deletions = vec!["folderBBBBBB", "folderEEEEEE"];
+    let expected_deletions = &["folderBBBBBB", "folderEEEEEE"];
     let expected_telem = StructureCounts {
         local_deletes: 1,
         remote_deletes: 1,
@@ -1086,7 +1086,7 @@ fn locally_deleted_remotely_modified() {
             ("bookmarkGGGG", RemoteWithNewRemoteStructure)
         })
     });
-    let expected_deletions = vec![
+    let expected_deletions = &[
         "bookmarkCCCC",
         "bookmarkEEEE",
         "folderBBBBBB",
@@ -1128,13 +1128,16 @@ fn nonexistent_on_one_side() {
     let mut expected_root = Item::new(ROOT_GUID, Kind::Folder);
     expected_root.needs_merge = true;
     let expected_tree = merged_nodes!(ROOT_GUID, Unchanged, {});
+    let expected_deletions = &["bookmarkAAAA", "bookmarkBBBB"];
     let expected_telem = StructureCounts {
         ..StructureCounts::default()
     };
 
     assert_eq!(&expected_tree, merged_root.node());
 
-    assert_eq!(merged_root.deletions().count(), 0);
+    let mut deletions = merged_root.deletions().collect::<Vec<_>>();
+    deletions.sort();
+    assert_eq!(deletions, expected_deletions);
 
     let ops = merged_root.completion_ops();
     assert_eq!(
@@ -1214,7 +1217,7 @@ fn clear_folder_then_delete() {
             ("bookmarkCCCC", Remote)
         })
     });
-    let expected_deletions = vec!["folderAAAAAA", "folderDDDDDD"];
+    let expected_deletions = &["folderAAAAAA", "folderDDDDDD"];
     let expected_telem = StructureCounts {
         merged_nodes: 7,
         ..StructureCounts::default()
@@ -1295,7 +1298,7 @@ fn newer_move_to_deleted() {
             ("bookmarkBBBB", Remote)
         })
     });
-    let expected_deletions = vec!["folderAAAAAA", "folderCCCCCC"];
+    let expected_deletions = &["folderAAAAAA", "folderCCCCCC"];
     let expected_telem = StructureCounts {
         local_deletes: 1,
         remote_deletes: 1,
@@ -1771,7 +1774,7 @@ fn left_pane_root() {
     let merged_root = merger.merge().unwrap();
 
     let expected_tree = merged_nodes!(ROOT_GUID, Local);
-    let expected_deletions = vec![
+    let expected_deletions = &[
         "folderLEFTPC",
         "folderLEFTPF",
         "folderLEFTPQ",
@@ -1828,7 +1831,7 @@ fn livemarks() {
         ("toolbar_____", LocalWithNewLocalStructure),
         ("unfiled_____", RemoteWithNewRemoteStructure)
     });
-    let expected_deletions = vec![
+    let expected_deletions = &[
         "livemarkAAAA",
         "livemarkBBBB",
         "livemarkCCCC",
@@ -1925,7 +1928,7 @@ fn non_syncable_items() {
             ("bookmarkGGGG", Remote)
         })
     });
-    let expected_deletions = vec![
+    let expected_deletions = &[
         "bookmarkEEEE", // Non-syncable locally.
         "bookmarkFFFF", // Non-syncable locally.
         "bookmarkIIII", // Non-syncable remotely.
@@ -2267,7 +2270,7 @@ fn invalid_guids() {
             ("item00000004", LocalWithNewLocalStructure)
         })
     });
-    let expected_deletions = vec!["", "!@#$%^", "loooooongGUID", "shortGUID"];
+    let expected_deletions = &["", "!@#$%^", "loooooongGUID", "shortGUID"];
     let expected_telem = StructureCounts {
         merged_nodes: 9,
         ..StructureCounts::default()
@@ -2463,7 +2466,7 @@ fn deleted_user_content_roots() {
 
     assert_eq!(&expected_tree, merged_root.node());
 
-    assert_eq!(merged_root.deletions().count(), 0);
+    assert_eq!(merged_root.deletions().count(), 1);
 
     assert_eq!(merged_root.counts(), &expected_telem);
 }
@@ -2652,7 +2655,7 @@ fn reupload_replace() {
             ("folderGGGGGG", Local)
         })
     });
-    let expected_deletions = vec![
+    let expected_deletions = &[
         // C is invalid on both sides, so we need to upload a tombstone.
         "bookmarkCCCC",
         // E is invalid locally and deleted remotely, so doesn't need a

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1143,8 +1143,8 @@ fn nonexistent_on_one_side() {
     assert_eq!(
         ops.summarize(),
         &[
-            "Flag bookmarkBBBB as merged",
-            "Remove tombstone for bookmarkAAAA",
+            "Flag remote bookmarkBBBB as merged",
+            "Delete local tombstone bookmarkAAAA",
         ]
     );
 
@@ -2216,7 +2216,7 @@ fn invalid_guids() {
             let count = self.0.get();
             self.0.set(count + 1);
             assert!(
-                &[")(*&", "shortGUID", "loooooongGUID", "!@#$%^", "",].contains(&old_guid.as_str()),
+                &[")(*&", "shortGUID", "loooooongGUID", "!@#$%^", ""].contains(&old_guid.as_str()),
                 "Didn't expect to generate new GUID for {}",
                 old_guid
             );
@@ -2688,15 +2688,17 @@ fn reupload_replace() {
         &[
             "Apply remote bookmarkFFFF",
             "Apply remote bookmarkKKKK",
-            "Delete bookmarkCCCC from local tree",
-            "Delete bookmarkEEEE from local tree",
-            "Delete bookmarkHHHH from local tree",
-            "Flag bookmarkAAAA for upload",
-            "Flag bookmarkEEEE as merged",
-            "Flag bookmarkKKKK for upload",
-            "Flag folderBBBBBB for upload",
-            "Flag folderGGGGGG for upload",
-            "Flag toolbar_____ for upload",
+            "Delete local item bookmarkCCCC",
+            "Delete local item bookmarkEEEE",
+            "Delete local item bookmarkHHHH",
+            "Flag local bookmarkAAAA as unmerged",
+            "Flag local bookmarkKKKK as unmerged",
+            "Flag local folderBBBBBB as unmerged",
+            "Flag local folderGGGGGG as unmerged",
+            "Flag local toolbar_____ as unmerged",
+            "Flag remote bookmarkEEEE as merged",
+            "Insert local tombstone bookmarkCCCC",
+            "Insert local tombstone bookmarkJJJJ",
             "Move bookmarkKKKK into unfiled_____ at 0",
             "Upload item bookmarkAAAA",
             "Upload item bookmarkKKKK",
@@ -2706,8 +2708,6 @@ fn reupload_replace() {
             "Upload tombstone bookmarkCCCC",
             "Upload tombstone bookmarkIIII",
             "Upload tombstone bookmarkJJJJ",
-            "Upload tombstone for bookmarkCCCC",
-            "Upload tombstone for bookmarkJJJJ"
         ]
     );
 
@@ -2817,7 +2817,7 @@ fn completion_ops() {
             .iter()
             .map(|op| op.to_string())
             .collect::<Vec<String>>(),
-        &["Don't upload bookmarkFFFF",]
+        &["Flag local bookmarkFFFF as merged"]
     );
     assert_eq!(
         ops.set_remote_merged
@@ -2825,13 +2825,13 @@ fn completion_ops() {
             .map(|op| op.to_string())
             .collect::<Vec<String>>(),
         &[
-            "Flag menu________ as merged",
-            "Flag bookmarkEEEE as merged",
-            "Flag toolbar_____ as merged",
-            "Flag bookmarkGGGG as merged",
-            "Flag bookmarkHHHH as merged",
-            "Flag bookmarkFFFF as merged",
-            "Flag bookmarkIIII as merged",
+            "Flag remote menu________ as merged",
+            "Flag remote bookmarkEEEE as merged",
+            "Flag remote toolbar_____ as merged",
+            "Flag remote bookmarkGGGG as merged",
+            "Flag remote bookmarkHHHH as merged",
+            "Flag remote bookmarkFFFF as merged",
+            "Flag remote bookmarkIIII as merged",
         ]
     );
     let mut delete_local_items = ops
@@ -2840,17 +2840,14 @@ fn completion_ops() {
         .map(|op| op.to_string())
         .collect::<Vec<String>>();
     delete_local_items.sort();
-    assert_eq!(
-        delete_local_items,
-        &["Delete bookmarkIIII from local tree",]
-    );
+    assert_eq!(delete_local_items, &["Delete local item bookmarkIIII"]);
     assert!(ops.insert_local_tombstones.is_empty());
     assert_eq!(
         ops.upload_items
             .iter()
             .map(|op| op.to_string())
             .collect::<Vec<String>>(),
-        &["Upload item unfiled_____",]
+        &["Upload item unfiled_____"]
     );
     let mut upload_tombstones = ops
         .upload_tombstones
@@ -2858,7 +2855,7 @@ fn completion_ops() {
         .map(|op| op.to_string())
         .collect::<Vec<String>>();
     upload_tombstones.sort();
-    assert_eq!(upload_tombstones, &["Upload tombstone bookmarkJJJJ",]);
+    assert_eq!(upload_tombstones, &["Upload tombstone bookmarkJJJJ"]);
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -23,7 +23,7 @@ use env_logger;
 use crate::driver::{DefaultAbortSignal, Driver};
 use crate::error::{Error, ErrorKind, Result};
 use crate::guid::{Guid, ROOT_GUID, UNFILED_GUID};
-use crate::merge::{Merger, StructureCounts};
+use crate::merge::{to_strings, Merger, StructureCounts};
 use crate::tree::{
     self, Builder, Content, DivergedParent, DivergedParentGuid, Item, Kind, MergeState, Problem,
     ProblemCounts, Problems, Tree, Validity,
@@ -2787,10 +2787,7 @@ fn completion_ops() {
     let ops = merged_root.completion_ops();
     assert!(ops.change_guids.is_empty());
     assert_eq!(
-        ops.apply_remote_items
-            .iter()
-            .map(|op| op.to_string())
-            .collect::<Vec<String>>(),
+        to_strings(&ops.apply_remote_items).collect::<Vec<_>>(),
         &[
             "Apply remote bookmarkEEEE",
             "Apply remote bookmarkGGGG",
@@ -2799,10 +2796,7 @@ fn completion_ops() {
         ]
     );
     assert_eq!(
-        ops.apply_new_local_structure
-            .iter()
-            .map(|op| op.to_string())
-            .collect::<Vec<String>>(),
+        to_strings(&ops.apply_new_local_structure).collect::<Vec<_>>(),
         &[
             "Move bookmarkDDDD into menu________ at 1",
             "Move bookmarkBBBB into menu________ at 3",
@@ -2813,17 +2807,11 @@ fn completion_ops() {
     );
     assert!(ops.set_local_unmerged.is_empty());
     assert_eq!(
-        ops.set_local_merged
-            .iter()
-            .map(|op| op.to_string())
-            .collect::<Vec<String>>(),
+        to_strings(&ops.set_local_merged).collect::<Vec<_>>(),
         &["Flag local bookmarkFFFF as merged"]
     );
     assert_eq!(
-        ops.set_remote_merged
-            .iter()
-            .map(|op| op.to_string())
-            .collect::<Vec<String>>(),
+        to_strings(&ops.set_remote_merged).collect::<Vec<_>>(),
         &[
             "Flag remote menu________ as merged",
             "Flag remote bookmarkEEEE as merged",
@@ -2834,26 +2822,15 @@ fn completion_ops() {
             "Flag remote bookmarkIIII as merged",
         ]
     );
-    let mut delete_local_items = ops
-        .delete_local_items
-        .iter()
-        .map(|op| op.to_string())
-        .collect::<Vec<String>>();
+    let mut delete_local_items = to_strings(&ops.delete_local_items).collect::<Vec<_>>();
     delete_local_items.sort();
     assert_eq!(delete_local_items, &["Delete local item bookmarkIIII"]);
     assert!(ops.insert_local_tombstones.is_empty());
     assert_eq!(
-        ops.upload_items
-            .iter()
-            .map(|op| op.to_string())
-            .collect::<Vec<String>>(),
+        to_strings(&ops.upload_items).collect::<Vec<_>>(),
         &["Upload item unfiled_____"]
     );
-    let mut upload_tombstones = ops
-        .upload_tombstones
-        .iter()
-        .map(|op| op.to_string())
-        .collect::<Vec<String>>();
+    let mut upload_tombstones = to_strings(&ops.upload_tombstones).collect::<Vec<_>>();
     upload_tombstones.sort();
     assert_eq!(upload_tombstones, &["Upload tombstone bookmarkJJJJ"]);
 }
@@ -2914,10 +2891,7 @@ fn problems() {
     let mut summary = problems.summarize().collect::<Vec<_>>();
     summary.sort_by(|a, b| a.guid().cmp(b.guid()));
     assert_eq!(
-        summary
-            .into_iter()
-            .map(|s| s.to_string())
-            .collect::<Vec<String>>(),
+        to_strings(&summary).collect::<Vec<_>>(),
         &[
             "bookmarkAAAA is an orphan",
             "bookmarkBBBB is in children of folderCCCCCC and has parent folderDDDDDD",

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -478,13 +478,10 @@ fn unchanged_newer_changed_older() {
     });
     let expected_deletions = vec!["folderAAAAAA", "folderCCCCCC"];
     let expected_telem = StructureCounts {
-        remote_revives: 0,
         local_deletes: 1,
-        local_revives: 0,
         remote_deletes: 1,
-        dupes: 0,
         merged_nodes: 6,
-        merged_deletions: 2,
+        ..StructureCounts::default()
     };
 
     assert_eq!(&expected_tree, merged_root.node());
@@ -929,13 +926,10 @@ fn complex_orphaning() {
     });
     let expected_deletions = vec!["folderBBBBBB", "folderEEEEEE"];
     let expected_telem = StructureCounts {
-        remote_revives: 0,
         local_deletes: 1,
-        local_revives: 0,
         remote_deletes: 1,
-        dupes: 0,
         merged_nodes: 7,
-        merged_deletions: 2,
+        ..StructureCounts::default()
     };
 
     assert_eq!(&expected_tree, merged_root.node());
@@ -1023,13 +1017,10 @@ fn locally_modified_remotely_deleted() {
     });
     let expected_deletions = vec!["folderBBBBBB", "folderEEEEEE"];
     let expected_telem = StructureCounts {
-        remote_revives: 0,
         local_deletes: 1,
-        local_revives: 0,
         remote_deletes: 1,
-        dupes: 0,
         merged_nodes: 7,
-        merged_deletions: 2,
+        ..StructureCounts::default()
     };
 
     assert_eq!(&expected_tree, merged_root.node());
@@ -1104,11 +1095,8 @@ fn locally_deleted_remotely_modified() {
     let expected_telem = StructureCounts {
         remote_revives: 1,
         local_deletes: 2,
-        local_revives: 0,
-        remote_deletes: 0,
-        dupes: 0,
         merged_nodes: 4,
-        merged_deletions: 4,
+        ..StructureCounts::default()
     };
 
     assert_eq!(&expected_tree, merged_root.node());
@@ -1140,17 +1128,22 @@ fn nonexistent_on_one_side() {
     let mut expected_root = Item::new(ROOT_GUID, Kind::Folder);
     expected_root.needs_merge = true;
     let expected_tree = merged_nodes!(ROOT_GUID, Unchanged, {});
-    let expected_deletions = vec!["bookmarkAAAA", "bookmarkBBBB"];
     let expected_telem = StructureCounts {
-        merged_deletions: 2,
         ..StructureCounts::default()
     };
 
     assert_eq!(&expected_tree, merged_root.node());
 
-    let mut deletions = merged_root.deletions().collect::<Vec<_>>();
-    deletions.sort();
-    assert_eq!(deletions, expected_deletions);
+    assert_eq!(merged_root.deletions().count(), 0);
+
+    let ops = merged_root.completion_ops();
+    assert_eq!(
+        ops.summarize(),
+        &[
+            "Flag bookmarkBBBB as merged",
+            "Remove tombstone for bookmarkAAAA",
+        ]
+    );
 
     assert_eq!(merged_root.counts(), &expected_telem);
 }
@@ -1224,7 +1217,6 @@ fn clear_folder_then_delete() {
     let expected_deletions = vec!["folderAAAAAA", "folderDDDDDD"];
     let expected_telem = StructureCounts {
         merged_nodes: 7,
-        merged_deletions: 2,
         ..StructureCounts::default()
     };
 
@@ -1305,13 +1297,10 @@ fn newer_move_to_deleted() {
     });
     let expected_deletions = vec!["folderAAAAAA", "folderCCCCCC"];
     let expected_telem = StructureCounts {
-        remote_revives: 0,
         local_deletes: 1,
-        local_revives: 0,
         remote_deletes: 1,
-        dupes: 0,
         merged_nodes: 6,
-        merged_deletions: 2,
+        ..StructureCounts::default()
     };
 
     assert_eq!(&expected_tree, merged_root.node());
@@ -1383,13 +1372,8 @@ fn deduping_multiple_candidates() {
         })
     });
     let expected_telem = StructureCounts {
-        remote_revives: 0,
-        local_deletes: 0,
-        local_revives: 0,
-        remote_deletes: 0,
-        dupes: 0,
         merged_nodes: 6,
-        merged_deletions: 0,
+        ..StructureCounts::default()
     };
 
     assert_eq!(&expected_tree, merged_root.node());
@@ -1465,13 +1449,9 @@ fn deduping_local_newer() {
         })
     });
     let expected_telem = StructureCounts {
-        remote_revives: 0,
-        local_deletes: 0,
-        local_revives: 0,
-        remote_deletes: 0,
         dupes: 2,
         merged_nodes: 5,
-        merged_deletions: 0,
+        ..StructureCounts::default()
     };
 
     assert_eq!(&expected_tree, merged_root.node());
@@ -1621,13 +1601,9 @@ fn deduping_remote_newer() {
         })
     });
     let expected_telem = StructureCounts {
-        remote_revives: 0,
-        local_deletes: 0,
-        local_revives: 0,
-        remote_deletes: 0,
         dupes: 6,
         merged_nodes: 11,
-        merged_deletions: 0,
+        ..StructureCounts::default()
     };
 
     assert_eq!(&expected_tree, merged_root.node());
@@ -1760,13 +1736,9 @@ fn complex_deduping() {
         })
     });
     let expected_telem = StructureCounts {
-        remote_revives: 0,
-        local_deletes: 0,
-        local_revives: 0,
-        remote_deletes: 0,
         dupes: 6,
         merged_nodes: 9,
-        merged_deletions: 0,
+        ..StructureCounts::default()
     };
 
     assert_eq!(&expected_tree, merged_root.node());
@@ -1806,7 +1778,6 @@ fn left_pane_root() {
         "folderLEFTPR",
     ];
     let expected_telem = StructureCounts {
-        merged_deletions: 4,
         ..StructureCounts::default()
     };
 
@@ -1866,8 +1837,6 @@ fn livemarks() {
     ];
     let expected_telem = StructureCounts {
         merged_nodes: 3,
-        // A, B, and C are counted twice, since they exist on both sides.
-        merged_deletions: 8,
         ..StructureCounts::default()
     };
 
@@ -1971,7 +1940,6 @@ fn non_syncable_items() {
     ];
     let expected_telem = StructureCounts {
         merged_nodes: 5,
-        merged_deletions: 16,
         ..StructureCounts::default()
     };
 
@@ -2081,13 +2049,9 @@ fn applying_two_empty_folders_matches_only_one() {
         })
     });
     let expected_telem = StructureCounts {
-        remote_revives: 0,
-        local_deletes: 0,
-        local_revives: 0,
-        remote_deletes: 0,
         dupes: 1,
         merged_nodes: 4,
-        merged_deletions: 0,
+        ..StructureCounts::default()
     };
 
     assert_eq!(&expected_tree, merged_root.node());
@@ -2150,13 +2114,9 @@ fn deduping_ignores_parent_title() {
         })
     });
     let expected_telem = StructureCounts {
-        remote_revives: 0,
-        local_deletes: 0,
-        local_revives: 0,
-        remote_deletes: 0,
         dupes: 1,
         merged_nodes: 2,
-        merged_deletions: 0,
+        ..StructureCounts::default()
     };
 
     assert_eq!(&expected_tree, merged_root.node());
@@ -2310,7 +2270,6 @@ fn invalid_guids() {
     let expected_deletions = vec!["", "!@#$%^", "loooooongGUID", "shortGUID"];
     let expected_telem = StructureCounts {
         merged_nodes: 9,
-        merged_deletions: 4,
         ..StructureCounts::default()
     };
 
@@ -2498,20 +2457,13 @@ fn deleted_user_content_roots() {
         })
     });
     let expected_telem = StructureCounts {
-        remote_revives: 0,
-        local_deletes: 0,
-        local_revives: 0,
-        remote_deletes: 0,
-        dupes: 0,
         merged_nodes: 4,
-        merged_deletions: 1,
+        ..StructureCounts::default()
     };
 
     assert_eq!(&expected_tree, merged_root.node());
 
-    // TODO(lina): Remove invalid tombstones from both sides.
-    let deletions = merged_root.deletions().collect::<Vec<_>>();
-    assert_eq!(deletions, vec![Into::<Guid>::into("toolbar_____")]);
+    assert_eq!(merged_root.deletions().count(), 0);
 
     assert_eq!(merged_root.counts(), &expected_telem);
 }
@@ -2716,10 +2668,6 @@ fn reupload_replace() {
     ];
     let expected_telem = StructureCounts {
         merged_nodes: 10,
-        // C is double-counted: it's deleted on both sides, so
-        // `merged_deletions` is 6, even though we only have 5 expected
-        // deletions.
-        merged_deletions: 6,
         ..StructureCounts::default()
     };
 
@@ -2730,31 +2678,33 @@ fn reupload_replace() {
     assert_eq!(deletions, expected_deletions);
 
     let ops = merged_root.completion_ops();
-    let mut delete_local_items = ops
-        .delete_local_items
-        .iter()
-        .map(|op| op.to_string())
-        .collect::<Vec<String>>();
-    delete_local_items.sort();
+    let mut summary = ops.summarize();
+    summary.sort();
     assert_eq!(
-        delete_local_items,
+        summary,
         &[
+            "Apply remote bookmarkFFFF",
+            "Apply remote bookmarkKKKK",
             "Delete bookmarkCCCC from local tree",
             "Delete bookmarkEEEE from local tree",
             "Delete bookmarkHHHH from local tree",
-        ]
-    );
-    let mut insert_local_tombstones = ops
-        .insert_local_tombstones
-        .iter()
-        .map(|op| op.to_string())
-        .collect::<Vec<String>>();
-    insert_local_tombstones.sort();
-    assert_eq!(
-        insert_local_tombstones,
-        &[
+            "Flag bookmarkAAAA for upload",
+            "Flag bookmarkEEEE as merged",
+            "Flag bookmarkKKKK for upload",
+            "Flag folderBBBBBB for upload",
+            "Flag folderGGGGGG for upload",
+            "Flag toolbar_____ for upload",
+            "Move bookmarkKKKK into unfiled_____ at 0",
+            "Upload item bookmarkAAAA",
+            "Upload item bookmarkKKKK",
+            "Upload item folderBBBBBB",
+            "Upload item folderGGGGGG",
+            "Upload item toolbar_____",
+            "Upload tombstone bookmarkCCCC",
+            "Upload tombstone bookmarkIIII",
+            "Upload tombstone bookmarkJJJJ",
             "Upload tombstone for bookmarkCCCC",
-            "Upload tombstone for bookmarkJJJJ",
+            "Upload tombstone for bookmarkJJJJ"
         ]
     );
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -76,12 +76,7 @@ impl Tree {
         Node(self, &self.entries[0])
     }
 
-    /// Returns an iterator for all node and tombstone GUIDs.
-    pub fn guids(&self) -> impl Iterator<Item = &Guid> {
-        self.entries.iter().map(|entry| &entry.item.guid)
-    }
-
-    /// Returns an iterator for all tombstoned GUIDs.
+    /// Returns the set of all tombstoned GUIDs.
     #[inline]
     pub fn deletions(&self) -> &HashSet<Guid> {
         &self.deleted_guids
@@ -106,6 +101,14 @@ impl Tree {
     #[inline]
     pub fn mentions(&self, guid: &Guid) -> bool {
         self.entry_index_by_guid.contains_key(guid) || self.deleted_guids.contains(guid)
+    }
+
+    /// Returns an iterator for all node and tombstone GUIDs.
+    pub fn guids(&self) -> impl Iterator<Item = &Guid> {
+        self.entries
+            .iter()
+            .map(|entry| &entry.item.guid)
+            .chain(self.deleted_guids.iter())
     }
 
     /// Returns the node for a given `guid`, or `None` if a node with the `guid`


### PR DESCRIPTION
This commit adds completion ops for deleting local items (to apply
remote tombstones), inserting new tombstones (to delete non-syncable
and invalid items), and uploading tombstones (to avoid an extra table
scan when staging outgoing tombstones).

These ops also help avoid extra work when applying tombstones for items
that don't exist locally, or uploading tombstones for items that don't
exist remotely.