### PR TITLE
Recorded invalid items as tree problem

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2860,6 +2860,7 @@ fn problems() {
                 DivergedParentGuid::NonFolder("bookmarkGGGG".into()).into(),
             ]),
         )
+        .note(&"bookmarkRRRR".into(), Problem::InvalidItem)
         .note(
             &"bookmarkHHHH".into(),
             Problem::DivergedParents(vec![
@@ -2886,7 +2887,8 @@ fn problems() {
             Problem::DivergedParents(vec![
                 DivergedParentGuid::Deleted("folderQQQQQQ".into()).into()
             ]),
-        );
+        )
+        .note(&"bookmarkQQQQ".into(), Problem::InvalidItem);
 
     let mut summary = problems.summarize().collect::<Vec<_>>();
     summary.sort_by(|a, b| a.guid().cmp(b.guid()));
@@ -2900,6 +2902,8 @@ fn problems() {
              nonexistent parent folderKKKKKK",
             "bookmarkLLLL has diverged parents",
             "bookmarkPPPP has deleted parent folderQQQQQQ",
+            "bookmarkQQQQ is invalid",
+            "bookmarkRRRR is invalid",
             "folderMMMMMM has nonexistent child bookmarkNNNN",
             "folderMMMMMM has nonexistent child bookmarkOOOO",
             "menu________ is a user content root, but is in children of unfiled_____",
@@ -2919,6 +2923,7 @@ fn problems() {
             parent_child_disagreements: 7,
             deleted_children: 0,
             missing_children: 2,
+            invalid_items: 2,
         }
     );
 }


### PR DESCRIPTION
This commit fixes #58. 

It includes the addition of `Problem::InvalidItem` and `ProblemCounts::invalid_items` and functionality to track the occurrences of invalid items.